### PR TITLE
Deunsafication and testing of `sonic` protocol and introducing `sonic::service`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87bf87e6e8b47264efa9bde63d6225c6276a52e05e91bf37eaa8afd0032d6b71"
 dependencies = [
  "askama_shared",
- "proc-macro2",
+ "proc-macro2 1.0.56",
  "syn 1.0.109",
 ]
 
@@ -227,8 +227,8 @@ dependencies = [
  "nom",
  "num-traits",
  "percent-encoding",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "serde",
  "syn 1.0.109",
  "toml",
@@ -275,8 +275,8 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -286,8 +286,8 @@ version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -423,8 +423,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb524613be645939e280b7279f7b017f98cf7f5ef084ec374df373530e73277"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -499,8 +499,8 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "regex",
  "rustc-hash",
  "shlex",
@@ -570,7 +570,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b872f3528eeeb4370ee73b51194dc1cd93680c2d0eb6c7a223889038d2c1a167"
 dependencies = [
- "quote",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -597,8 +597,8 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -607,6 +607,20 @@ name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.15",
+]
 
 [[package]]
 name = "byteorder"
@@ -821,8 +835,8 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -833,8 +847,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -1059,8 +1073,8 @@ dependencies = [
  "itoa 0.4.8",
  "matches",
  "phf 0.8.0",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "smallvec",
  "syn 1.0.109",
 ]
@@ -1071,7 +1085,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e"
 dependencies = [
- "quote",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -1126,8 +1140,8 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "scratch",
  "syn 2.0.15",
 ]
@@ -1144,8 +1158,8 @@ version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -1167,8 +1181,8 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "strsim",
  "syn 1.0.109",
 ]
@@ -1180,7 +1194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
- "quote",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -1213,8 +1227,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
  "darling",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -1235,8 +1249,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -1628,8 +1642,8 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -1888,8 +1902,8 @@ dependencies = [
  "log",
  "mac",
  "markup5ever",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2225,7 +2239,7 @@ dependencies = [
  "string_cache",
  "term",
  "tiny-keccak",
- "unicode-xid",
+ "unicode-xid 0.2.4",
 ]
 
 [[package]]
@@ -2276,6 +2290,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "librocksdb-sys"
@@ -2354,8 +2374,8 @@ checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
 dependencies = [
  "beef",
  "fnv",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "regex-syntax 0.6.29",
  "syn 1.0.109",
 ]
@@ -2485,8 +2505,8 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2624,8 +2644,8 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8795add3e14028f11f8e848bd3294898a8294767b3776b6f733560d33bd2530b"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -2758,6 +2778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2786,8 +2807,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2882,8 +2903,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -3098,8 +3119,8 @@ dependencies = [
  "phf_generator 0.8.0",
  "phf_shared 0.8.0",
  "proc-macro-hack",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -3142,8 +3163,8 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -3247,8 +3268,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
  "version_check",
 ]
@@ -3259,8 +3280,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "version_check",
 ]
 
@@ -3272,11 +3293,51 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "proc-macro2"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax 0.6.29",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
 ]
 
 [[package]]
@@ -3294,8 +3355,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -3307,6 +3368,12 @@ checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -3329,11 +3396,20 @@ dependencies = [
 
 [[package]]
 name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.56",
 ]
 
 [[package]]
@@ -3421,6 +3497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3607,8 +3692,8 @@ version = "0.7.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1c672430eb41556291981f45ca900a0239ad007242d1cb4b4167af842db666"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -3722,6 +3807,18 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rxml"
@@ -3851,7 +3948,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e03b3a19daa79085439113c746d2946e5e6effd2d9039bf092bb08df915487b2"
 dependencies = [
- "quote",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -3935,8 +4032,8 @@ version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -4137,6 +4234,7 @@ dependencies = [
  "base64 0.13.1",
  "bincode",
  "bitvec",
+ "bytemuck",
  "byteorder",
  "bzip2",
  "chitchat",
@@ -4173,6 +4271,8 @@ dependencies = [
  "once_cell",
  "optics",
  "parse_wiki_text",
+ "proptest",
+ "proptest-derive",
  "quick-xml 0.23.1",
  "rand 0.8.5",
  "rayon",
@@ -4228,8 +4328,8 @@ checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
 dependencies = [
  "phf_generator 0.10.0",
  "phf_shared 0.10.0",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
 ]
 
 [[package]]
@@ -4251,8 +4351,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -4265,12 +4365,23 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "unicode-ident",
 ]
 
@@ -4280,8 +4391,8 @@ version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "unicode-ident",
 ]
 
@@ -4495,8 +4606,8 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -4654,8 +4765,8 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -4806,8 +4917,8 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -4873,6 +4984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4922,6 +5039,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -5016,6 +5139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5072,8 +5204,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
@@ -5096,7 +5228,7 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
- "quote",
+ "quote 1.0.26",
  "wasm-bindgen-macro-support",
 ]
 
@@ -5106,8 +5238,8 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,4 +92,7 @@ async-channel = "1.8.0"
 lru = "0.10.0"
 url = { version = "2.4.0", features = ["serde"] }
 anyhow = { version = "1.0.72", features = ["backtrace"] }
+bytemuck = { version = "1.13.1", features = ["derive"] }
+proptest = "1.2.0"
+proptest-derive = "0.3.0"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -92,6 +92,7 @@ async-channel = { workspace = true }
 lru = { workspace = true }
 url = { workspace = true }
 anyhow = { workspace = true }
+bytemuck = { workspace = true }
 
 [build-dependencies]
 lalrpop = { workspace = true }
@@ -99,6 +100,8 @@ lalrpop = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 maplit = { workspace = true }
+proptest = { workspace = true }
+proptest-derive = { workspace = true }
 
 [[bench]]
 name = "search-preindexed"

--- a/core/examples/mapreduce_manager.rs
+++ b/core/examples/mapreduce_manager.rs
@@ -5,7 +5,7 @@ use stract::mapreduce::{Manager, Map, Reduce, StatelessWorker};
 use tracing::Level;
 use tracing_subscriber::FmtSubscriber;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 struct Job {
     id: usize,
 }

--- a/core/src/api/webgraph.rs
+++ b/core/src/api/webgraph.rs
@@ -69,7 +69,7 @@ pub async fn similar_sites(
 
     match conn
         .send_with_timeout(
-            crate::entrypoint::webgraph_server::SimilarSites {
+            &crate::entrypoint::webgraph_server::SimilarSites {
                 sites: params.sites,
                 top_n: params.top_n,
             },
@@ -112,7 +112,7 @@ pub async fn knows_site(
 
     match conn
         .send_with_timeout(
-            crate::entrypoint::webgraph_server::Knows { site: params.site },
+            &crate::entrypoint::webgraph_server::Knows { site: params.site },
             Duration::from_secs(2),
         )
         .await

--- a/core/src/crawler/mod.rs
+++ b/core/src/crawler/mod.rs
@@ -175,15 +175,7 @@ impl Crawler {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-pub enum Request {
-    NewJobs {
-        responses: Vec<JobResponse>,
-        num_jobs: usize,
-    },
-}
-
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum Response {
     NewJobs { jobs: Vec<Job> },
     Done,

--- a/core/src/crawler/worker.rs
+++ b/core/src/crawler/worker.rs
@@ -127,7 +127,7 @@ impl Worker {
 
                 let res = conn
                     .send_with_timeout(
-                        NewJobs {
+                        &NewJobs {
                             responses: results,
                             num_jobs: 2 * self.num_jobs_per_fetch,
                         },

--- a/core/src/distributed/sonic/mod.rs
+++ b/core/src/distributed/sonic/mod.rs
@@ -63,7 +63,7 @@ struct Header {
 
 impl<Req, Res> Server<Req, Res>
 where
-    Req: Serialize + DeserializeOwned,
+    Req: DeserializeOwned,
 {
     pub async fn bind(addr: impl ToSocketAddrs) -> Result<Self> {
         let listener = TcpListener::bind(addr).await?;
@@ -97,8 +97,8 @@ where
 
 impl<Req, Res> Connection<Req, Res>
 where
-    Req: Serialize + DeserializeOwned,
-    Res: Serialize + DeserializeOwned,
+    Req: Serialize,
+    Res: DeserializeOwned,
 {
     pub async fn create(server: impl ToSocketAddrs) -> Result<Self> {
         Self::create_with_timeout(server, Duration::from_secs(30)).await
@@ -158,8 +158,7 @@ where
 
 impl<Req, Res> Request<Req, Res>
 where
-    Req: Serialize + DeserializeOwned,
-    Res: Serialize + DeserializeOwned,
+    Res: Serialize,
 {
     pub async fn respond(mut self, response: Res) -> Result<()> {
         let bytes = bincode::serialize(&response).unwrap();

--- a/core/src/distributed/sonic/service.rs
+++ b/core/src/distributed/sonic/service.rs
@@ -1,0 +1,316 @@
+use std::{marker::PhantomData, net::SocketAddr, time::Duration};
+
+use tokio::net::ToSocketAddrs;
+
+use super::{Error, Result};
+
+#[async_trait::async_trait]
+pub trait Service: Sized {
+    type Request: serde::Serialize + serde::de::DeserializeOwned;
+    type Response: serde::Serialize + serde::de::DeserializeOwned;
+
+    async fn handle(req: Self::Request, server: &mut Self) -> Result<Self::Response>;
+}
+
+#[async_trait::async_trait]
+pub trait Message<S: Service> {
+    type Response;
+    async fn handle(self, server: &mut S) -> Result<Self::Response>;
+}
+pub trait Wrapper<S: Service>: Message<S> {
+    fn wrap_request(req: Self) -> S::Request;
+    fn unwrap_response(res: S::Response) -> Option<Self::Response>;
+}
+
+pub struct Server<S: Service> {
+    inner: super::Server<S::Request, S::Response>,
+    service: S,
+}
+
+pub struct Connection<S: Service> {
+    inner: super::Connection<S::Request, S::Response>,
+    marker: PhantomData<S>,
+}
+
+pub struct ResilientConnection<S: Service, Rt: Iterator<Item = Duration>> {
+    addr: SocketAddr,
+    retry: Rt,
+    marker: PhantomData<S>,
+}
+
+impl<S: Service> Server<S> {
+    pub async fn bind(service: S, addr: impl ToSocketAddrs) -> Result<Self> {
+        Ok(Server {
+            inner: super::Server::bind(addr).await?,
+            service,
+        })
+    }
+    pub async fn accept(&mut self) -> Result<()> {
+        let mut req = self.inner.accept().await?;
+        let res = S::handle(req.take_body(), &mut self.service).await?;
+        req.respond(res).await
+    }
+}
+
+impl<S: Service> Connection<S> {
+    #[allow(dead_code)]
+    pub async fn create(server: impl ToSocketAddrs) -> Result<Self> {
+        Ok(Connection {
+            inner: super::Connection::create(server).await?,
+            marker: PhantomData,
+        })
+    }
+
+    pub async fn create_with_timeout(
+        server: impl ToSocketAddrs,
+        timeout: Duration,
+    ) -> Result<Self> {
+        Ok(Connection {
+            inner: super::Connection::create_with_timeout(server, timeout).await?,
+            marker: PhantomData,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub async fn send_without_timeout<R: Wrapper<S>>(self, request: R) -> Result<R::Response> {
+        let res = self
+            .inner
+            .send_without_timeout(&R::wrap_request(request))
+            .await?;
+        Ok(R::unwrap_response(res).unwrap())
+    }
+
+    #[allow(dead_code)]
+    pub async fn send<R: Wrapper<S>>(self, request: R) -> Result<R::Response> {
+        let res = self.inner.send(&R::wrap_request(request)).await?;
+        Ok(R::unwrap_response(res).unwrap())
+    }
+
+    pub async fn send_with_timeout<R: Wrapper<S>>(
+        self,
+        request: R,
+        timeout: Duration,
+    ) -> Result<R::Response> {
+        let res = self
+            .inner
+            .send_with_timeout(&R::wrap_request(request), timeout)
+            .await?;
+        Ok(R::unwrap_response(res).unwrap())
+    }
+}
+
+impl<S: Service, Rt: Iterator<Item = Duration>> ResilientConnection<S, Rt> {
+    pub fn create(addr: SocketAddr, retry: Rt) -> Self {
+        Self {
+            addr,
+            retry,
+            marker: PhantomData,
+        }
+    }
+
+    pub async fn send_with_timeout<R: Wrapper<S>>(
+        mut self,
+        request: R,
+        timeout: Duration,
+    ) -> Result<R::Response>
+    where
+        R: Clone,
+    {
+        loop {
+            match Connection::create_with_timeout(&self.addr, timeout).await {
+                Ok(conn) => {
+                    let response = conn.send_with_timeout(request.clone(), timeout).await;
+                    if let Err(Error::ConnectionTimeout) = response {
+                        continue;
+                    }
+                    return response;
+                }
+                Err(Error::ConnectionTimeout) => {
+                    if let Some(timeout) = self.retry.next() {
+                        tokio::time::sleep(timeout).await;
+                        continue;
+                    } else {
+                        return Err(Error::ConnectionTimeout);
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! sonic_service {
+    ($service:ident, [$($req:ident),*$(,)?]) => {
+        mod service_impl__ {
+            #![allow(dead_code)]
+
+            use super::{$service, $($req),*};
+
+            use $crate::distributed::sonic;
+
+            #[derive(Debug, Clone, ::serde::Serialize, ::serde::Deserialize)]
+            pub enum Request {
+                $($req($req),)*
+            }
+            #[derive(::serde::Serialize, ::serde::Deserialize)]
+            pub enum Response {
+                $($req(<$req as sonic::service::Message<$service>>::Response),)*
+            }
+            $(
+                impl sonic::service::Wrapper<$service> for $req {
+                    fn wrap_request(req: Self) -> Request{
+                        Request::$req(req)
+                    }
+                    fn unwrap_response(res: <$service as sonic::service::Service>::Response) -> Option<Self::Response> {
+                        #[allow(irrefutable_let_patterns)]
+                        if let Response::$req(value) = res {
+                            Some(value)
+                        } else {
+                            None
+                        }
+                    }
+                }
+            )*
+            #[async_trait::async_trait]
+            impl sonic::service::Service for $service {
+                type Request = Request;
+                type Response = Response;
+
+                async fn handle(req: Request, server: &mut Self) -> sonic::Result<Response> {
+                    match req {
+                        $(
+                            Request::$req(value) => Ok(Response::$req(sonic::service::Message::handle(value, server).await?)),
+                        )*
+                    }
+                }
+            }
+            impl $service {
+                pub async fn bind(self, addr: impl ::tokio::net::ToSocketAddrs) -> sonic::Result<sonic::service::Server<Self>> {
+                    sonic::service::Server::bind(self, addr).await
+                }
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{marker::PhantomData, net::SocketAddr};
+
+    use super::{Connection, Server, Service, Wrapper};
+    use futures::Future;
+
+    struct ConnectionBuilder<S> {
+        addr: SocketAddr,
+        marker: PhantomData<S>,
+    }
+
+    impl<S: Service> ConnectionBuilder<S> {
+        async fn conn(&self) -> Result<Connection<S>, anyhow::Error> {
+            Ok(Connection::create(self.addr).await?)
+        }
+        async fn send<R: Wrapper<S>>(&self, req: R) -> Result<R::Response, anyhow::Error> {
+            Ok(self.conn().await?.send(req).await?)
+        }
+    }
+
+    fn fixture<
+        S: Service + Send + Sync + 'static,
+        B: Send + Sync + 'static,
+        Y: Future<Output = Result<B, anyhow::Error>> + Send,
+    >(
+        service: S,
+        con_fn: impl FnOnce(ConnectionBuilder<S>) -> Y + Send + 'static,
+    ) -> Result<B, anyhow::Error>
+    where
+        S::Request: Send + Sync + 'static + Clone,
+        S::Response: Send + Sync + 'static,
+    {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async move {
+                let mut server = Server::bind(service, ("127.0.0.1", 0)).await.unwrap();
+                let addr = server.inner.listener.local_addr().unwrap();
+
+                let svr_task: tokio::task::JoinHandle<Result<(), anyhow::Error>> =
+                    tokio::spawn(async move {
+                        loop {
+                            server.accept().await?;
+                        }
+                    });
+                let con_res = tokio::spawn(async move {
+                    con_fn(ConnectionBuilder {
+                        addr,
+                        marker: PhantomData,
+                    })
+                    .await
+                })
+                .await;
+                svr_task.abort();
+
+                con_res.unwrap_or_else(|err| panic!("connection failed: {err}"))
+            })
+    }
+
+    mod counter_service {
+        use serde::{Deserialize, Serialize};
+
+        use crate::distributed::sonic;
+
+        use super::super::Message;
+
+        pub struct CounterService {
+            pub counter: i32,
+        }
+
+        sonic_service!(CounterService, [Change, Reset]);
+
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        pub struct Change {
+            pub amount: i32,
+        }
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        pub struct Reset;
+
+        #[async_trait::async_trait]
+        impl Message<CounterService> for Change {
+            type Response = i32;
+
+            async fn handle(self, server: &mut CounterService) -> sonic::Result<Self::Response> {
+                server.counter += self.amount;
+                Ok(server.counter)
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl Message<CounterService> for Reset {
+            type Response = ();
+
+            async fn handle(self, server: &mut CounterService) -> sonic::Result<Self::Response> {
+                server.counter = 0;
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn simple_service() -> Result<(), anyhow::Error> {
+        use counter_service::*;
+
+        fixture(CounterService { counter: 0 }, |b| async move {
+            let val = b.send(Change { amount: 15 }).await?;
+            assert_eq!(val, 15);
+            let val = b.send(Change { amount: 15 }).await?;
+            assert_eq!(val, 30);
+            b.send(Reset).await?;
+            let val = b.send(Change { amount: 15 }).await?;
+            assert_eq!(val, 15);
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}

--- a/core/src/inverted_index.rs
+++ b/core/src/inverted_index.rs
@@ -501,7 +501,7 @@ pub struct SearchResult {
     pub documents: Vec<RetrievedWebpage>,
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RetrievedWebpage {
     pub title: String,
     pub url: String,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -111,7 +111,7 @@ pub enum Error {
     UnknownRobotsMetaTag,
 }
 
-pub(crate) type Result<T> = std::result::Result<T, anyhow::Error>;
+pub(crate) type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
 
 // taken from https://docs.rs/sled/0.34.7/src/sled/config.rs.html#445
 pub fn gen_temp_path() -> PathBuf {

--- a/core/src/mapreduce/mod.rs
+++ b/core/src/mapreduce/mod.rs
@@ -62,3 +62,6 @@ enum Task<T> {
     Job(T),
     AllFinished,
 }
+
+type MapReduceServer<I, O> = sonic::Server<Task<I>, Option<O>>;
+type MapReduceConnection<I, O> = sonic::Connection<Task<I>, Option<O>>;

--- a/core/src/searcher/distributed.rs
+++ b/core/src/searcher/distributed.rs
@@ -59,7 +59,7 @@ impl RemoteSearcher {
 
         if let Ok(Some(body)) = conn
             .send_with_timeout(
-                search_server::Search {
+                &search_server::Search {
                     query: query.clone(),
                 },
                 Duration::from_secs(1),
@@ -81,7 +81,7 @@ impl RemoteSearcher {
 
         if let Ok(Some(body)) = conn
             .send_with_timeout(
-                search_server::RetrieveWebsites {
+                &search_server::RetrieveWebsites {
                     websites: pointers.to_vec(),
                     query: original_query.to_string(),
                 },
@@ -99,7 +99,7 @@ impl RemoteSearcher {
 
         if let Ok(body) = conn
             .send_with_timeout(
-                search_server::GetWebpage {
+                &search_server::GetWebpage {
                     url: url.to_string(),
                 },
                 Duration::from_secs(1),
@@ -117,7 +117,7 @@ impl RemoteSearcher {
 
         if let Ok(body) = conn
             .send_with_timeout(
-                search_server::GetHomepageDescriptions {
+                &search_server::GetHomepageDescriptions {
                     urls: urls.to_vec(),
                 },
                 Duration::from_secs(1),

--- a/core/src/searcher/mod.rs
+++ b/core/src/searcher/mod.rs
@@ -66,7 +66,7 @@ pub struct SearchQuery {
     pub return_ranking_signals: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InitialWebsiteResult {
     pub spell_corrected_query: Option<Correction>,
     pub num_websites: usize,


### PR DESCRIPTION
Originally sonic used unsafe casts to read and write the Header for packets. This was "safe" as it was, but relied on the code reading and writing to make use that it used the correct types on each end of the protocol.

This introduces bytemuck which does the same thing, but safely. Safety comes from bytemuck asserting at compile-time that the Header is safe to cast to bytes, and that there are enough bytes when interpreting the received bytes.

In addition to this, this commit also introduces proptest testing of the sonic communication, by generating arbitray messages and sending them to a server, and asserting that the request and response is always as expected.