### PR TITLE
Add `#[serde(tag = "type", content = "value")]` to OpenAPI exposed types

### DIFF
--- a/core/src/api/webgraph.rs
+++ b/core/src/api/webgraph.rs
@@ -49,6 +49,7 @@ impl RemoteWebgraph {
 }
 
 #[derive(serde::Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SimilarSitesParams {
     pub sites: Vec<String>,
     pub top_n: usize,

--- a/core/src/bangs.rs
+++ b/core/src/bangs.rs
@@ -31,6 +31,7 @@ use crate::query::parser::Term;
 pub const BANG_PREFIX: char = '!';
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct Bang {
     #[serde(rename = "c")]
     pub(crate) category: Option<String>,
@@ -80,6 +81,7 @@ impl From<Url> for UrlWrapper {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct BangHit {
     pub bang: Bang,
     pub redirect_to: UrlWrapper,

--- a/core/src/entrypoint/webgraph_server.rs
+++ b/core/src/entrypoint/webgraph_server.rs
@@ -39,6 +39,7 @@ use crate::webgraph::WebgraphBuilder;
 use crate::Result;
 
 #[derive(serde::Serialize, serde::Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ScoredSite {
     pub site: String,
     pub score: f64,

--- a/core/src/ranking/signal.rs
+++ b/core/src/ranking/signal.rs
@@ -1108,6 +1108,7 @@ pub struct ComputedSignal {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SignalScore {
     pub coefficient: f64,
     pub value: f64,

--- a/core/src/search_prettifier/entity.rs
+++ b/core/src/search_prettifier/entity.rs
@@ -26,6 +26,7 @@ use crate::{
 };
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct DisplayedEntity {
     pub title: String,
     pub small_abstract: String,

--- a/core/src/search_prettifier/mod.rs
+++ b/core/src/search_prettifier/mod.rs
@@ -38,7 +38,7 @@ pub use entity::DisplayedEntity;
 pub use self::stack_overflow::{stackoverflow_snippet, StackOverflowAnswer, StackOverflowQuestion};
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
-#[serde(tag = "type")]
+#[serde(tag = "type", rename_all = "camelCase")]
 pub enum Snippet {
     Normal {
         date: Option<String>,
@@ -51,6 +51,7 @@ pub enum Snippet {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct HighlightedSpellCorrection {
     pub raw: String,
     pub highlighted: String,
@@ -162,6 +163,7 @@ fn generate_snippet(webpage: &RetrievedWebpage) -> Snippet {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct DisplayedWebpage {
     pub title: String,
     pub url: String,
@@ -174,6 +176,7 @@ pub struct DisplayedWebpage {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct DisplayedAnswer {
     pub title: String,
     pub url: String,
@@ -207,7 +210,7 @@ impl From<RetrievedWebpage> for DisplayedWebpage {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
-#[serde(tag = "type", content = "value")]
+#[serde(tag = "type", content = "value", rename_all = "camelCase")]
 pub enum Sidebar {
     Entity(DisplayedEntity),
     StackOverflow {

--- a/core/src/search_prettifier/mod.rs
+++ b/core/src/search_prettifier/mod.rs
@@ -38,6 +38,7 @@ pub use entity::DisplayedEntity;
 pub use self::stack_overflow::{stackoverflow_snippet, StackOverflowAnswer, StackOverflowQuestion};
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+#[serde(tag = "type")]
 pub enum Snippet {
     Normal {
         date: Option<String>,
@@ -206,6 +207,7 @@ impl From<RetrievedWebpage> for DisplayedWebpage {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+#[serde(tag = "type", content = "value")]
 pub enum Sidebar {
     Entity(DisplayedEntity),
     StackOverflow {

--- a/core/src/search_prettifier/stack_overflow.rs
+++ b/core/src/search_prettifier/stack_overflow.rs
@@ -28,6 +28,7 @@ use super::{Sidebar, Snippet};
 use crate::Result;
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct StackOverflowAnswer {
     pub body: Vec<CodeOrText>,
     pub date: String,
@@ -37,12 +38,13 @@ pub struct StackOverflowAnswer {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct StackOverflowQuestion {
     pub body: Vec<CodeOrText>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
-#[serde(tag = "type", content = "value")]
+#[serde(tag = "type", content = "value", rename_all = "camelCase")]
 pub enum CodeOrText {
     Code(String),
     Text(String),

--- a/core/src/search_prettifier/stack_overflow.rs
+++ b/core/src/search_prettifier/stack_overflow.rs
@@ -42,6 +42,7 @@ pub struct StackOverflowQuestion {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+#[serde(tag = "type", content = "value")]
 pub enum CodeOrText {
     Code(String),
     Text(String),

--- a/core/src/searcher/mod.rs
+++ b/core/src/searcher/mod.rs
@@ -45,6 +45,7 @@ pub enum SearchResult {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct WebsitesResult {
     pub spell_corrected_query: Option<HighlightedSpellCorrection>,
     pub webpages: Vec<DisplayedWebpage>,

--- a/core/src/widgets/calculator.rs
+++ b/core/src/widgets/calculator.rs
@@ -108,6 +108,7 @@ fn parse(expr: &str) -> Result<Box<Expr>> {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct Calculation {
     pub input: String,
     pub expr: Box<Expr>,

--- a/core/src/widgets/mod.rs
+++ b/core/src/widgets/mod.rs
@@ -31,7 +31,7 @@ pub enum Error {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
-#[serde(tag = "type", content = "value")]
+#[serde(tag = "type", content = "value", rename_all = "camelCase")]
 pub enum Widget {
     Calculator(Calculation),
 }

--- a/core/src/widgets/mod.rs
+++ b/core/src/widgets/mod.rs
@@ -31,6 +31,7 @@ pub enum Error {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type", content = "value")]
 pub enum Widget {
     Calculator(Calculation),
 }

--- a/frontend/public/js/explore.js
+++ b/frontend/public/js/explore.js
@@ -125,7 +125,7 @@ function updateSimilarSites() {
         },
         body: JSON.stringify({
             sites: sites,
-            top_n: parseInt(limit.value)
+            topN: parseInt(limit.value)
         })
     })
         .then(response => response.json())

--- a/ltr/generate_data.py
+++ b/ltr/generate_data.py
@@ -47,8 +47,8 @@ def search(q: str, top_n, optic=None):
         json={
             "query": q,
             "page": 0,
-            "num_results": top_n,
-            "return_ranking_signals": True,
+            "numResults": top_n,
+            "returnRankingSignals": True,
             "optic": optic,
         },
     )
@@ -66,7 +66,7 @@ def search(q: str, top_n, optic=None):
                 "domain": r["domain"],
                 "title": r["title"],
                 "url": r["url"],
-                "ranking_signals": r["ranking_signals"],
+                "rankingSignals": r["rankingSignals"],
                 "snippet": snip,
                 "body": r["body"],
             }
@@ -78,7 +78,7 @@ def search(q: str, top_n, optic=None):
 def score_prompt(query: str, res):
     r = {k: v for (k, v) in res.items() if k in ["domain", "title", "snippet"]}
     # r['domain_score'] = '{:f}'.format(
-    #     res['ranking_signals']['host_centrality'])
+    #     res['rankingSignals']['host_centrality'])
     encoded = json.dumps(r)
 
     inst = "You are a search engine evaluator. Evaluate the following result based on the query. A good search result is relevant to the query and comes from a trustworthy domain. The score for the search result should be between 0.0 and 1.0."
@@ -257,7 +257,7 @@ with tqdm(total=NUM_QUERIES) as pbar:
                     continue
 
                 url = res[i]["url"]
-                signals = res[i]["ranking_signals"]
+                signals = res[i]["rankingSignals"]
 
                 scores["query"].append(query)
                 scores["url"].append(url)
@@ -274,7 +274,7 @@ df = pd.DataFrame(scores)
 df = df.groupby(["query", "url"])
 df = df.mean().sort_values(by="score", ascending=False).reset_index()
 df["rank"] = df.groupby("query")["score"].rank(ascending=False)
-df["ranking_signals"] = df["url"].map(ranking_signals)
+df["rankingSignals"] = df["url"].map(ranking_signals)
 
 # convert to object
 res = json.loads(df.to_json(orient="records"))

--- a/optics/src/lib.rs
+++ b/optics/src/lib.rs
@@ -375,6 +375,7 @@ impl ToString for Rule {
 }
 
 #[derive(Debug, PartialEq, Default, Serialize, Deserialize, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SiteRankings {
     pub liked: Vec<String>,
     pub disliked: Vec<String>,


### PR DESCRIPTION
Makes them more ergonomic to work with in TypeScript in some scenarios.

The name of the content should perhaps be chosen on a case-by-case basis. For example, I've chosen to no have a separate `content` for `Snippet`.