### PR TITLE
Add more endpoints to the OpenAPI specification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ memmap = "0.7.0"
 once_cell = "1.13.1"
 regex = "1.6.0"
 http = "0.2.8"
-tower-http = { version = "0.4.0", features = ["compression-gzip"] }
+tower-http = { version = "0.4.0", features = ["compression-gzip", "cors"] }
 lalrpop-util = { version = "0.19.8", features = ["lexer"] }
 lalrpop = { version = "0.19.8", features = ["lexer"] }
 serde_urlencoded = "0.7.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,9 @@ default-run = "stract"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-dev = []
+default = ["cors"]
+dev = ["cors"]
+cors = []
 
 [[bin]]
 name = "stract"

--- a/core/src/alice/mod.rs
+++ b/core/src/alice/mod.rs
@@ -114,7 +114,7 @@ impl SimplifiedWebsite {
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, ToSchema)]
-#[serde(tag = "@type", rename_all = "camelCase")]
+#[serde(tag = "type", rename_all = "camelCase")]
 pub enum ExecutionState {
     BeginSearch {
         query: String,
@@ -172,6 +172,7 @@ impl Searcher {
             site_rankings: None,
             return_ranking_signals: false,
             flatten_response: false,
+            safe_search: Some(false),
         };
         tracing::debug!("searching at {:?}: {:#?}", self.url, query);
 

--- a/core/src/alice/mod.rs
+++ b/core/src/alice/mod.rs
@@ -40,6 +40,7 @@ use flate2::{bufread::GzDecoder, write::GzEncoder, Compression};
 use half::bf16;
 use tch::Tensor;
 use url::Url;
+use utoipa::ToSchema;
 
 use crate::{
     api::search::ApiSearchQuery,
@@ -90,7 +91,7 @@ pub enum Error {
     LastMessageNotUser,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct SimplifiedWebsite {
     pub title: String,
     pub text: String,
@@ -112,7 +113,7 @@ impl SimplifiedWebsite {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(tag = "@type", rename_all = "camelCase")]
 pub enum ExecutionState {
     BeginSearch {
@@ -401,7 +402,7 @@ impl Tokenizer {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, ToSchema)]
 /// base64 encoded `EncryptedState`
 pub struct EncodedEncryptedState(String);
 

--- a/core/src/api/alice.rs
+++ b/core/src/api/alice.rs
@@ -182,7 +182,7 @@ pub async fn alice_route(
             .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?
     };
 
-    let params = entrypoint::alice::Params {
+    let params = entrypoint::alice::AliceParams {
         message: params.message,
         prev_state: saved_state.map(|s| s.uuid),
         optic: params.optic,

--- a/core/src/api/autosuggest.rs
+++ b/core/src/api/autosuggest.rs
@@ -18,6 +18,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use axum::{extract, response::IntoResponse, Json};
 use serde::Serialize;
+use utoipa::{IntoParams, ToSchema};
 
 use super::State;
 
@@ -38,13 +39,28 @@ fn highlight(query: &str, suggestion: &str) -> String {
     new_suggestion
 }
 
-#[derive(Serialize)]
-struct Suggestion {
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Suggestion {
     highlighted: String,
     raw: String,
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize, IntoParams)]
+#[serde(rename_all = "camelCase")]
+pub struct AutosuggestQuery {
+    q: String,
+}
+
 #[allow(clippy::unused_async)]
+#[utoipa::path(
+    post,
+    path = "/beta/api/autosuggest",
+    params(AutosuggestQuery),
+    responses(
+        (status = 200, description = "Autosuggest", body = Vec<Suggestion>),
+    )
+)]
 pub async fn route(
     extract::State(state): extract::State<Arc<State>>,
     extract::Query(params): extract::Query<HashMap<String, String>>,

--- a/core/src/api/docs.rs
+++ b/core/src/api/docs.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::{search, webgraph};
+use super::{alice, autosuggest, fact_check, search, summarize, webgraph};
 use axum::Router;
 use utoipa::{Modify, OpenApi};
 use utoipa_swagger_ui::SwaggerUi;
@@ -24,7 +24,11 @@ use utoipa_swagger_ui::SwaggerUi;
         paths(
             search::api,
             webgraph::similar_sites,
-            webgraph::knows_site
+            webgraph::knows_site,
+            autosuggest::route,
+            summarize::summarize_route,
+            fact_check::fact_check_route,
+            alice::alice_route,
         ),
         components(
             schemas(
@@ -55,6 +59,15 @@ use utoipa_swagger_ui::SwaggerUi;
                 webgraph::SimilarSitesParams,
                 webgraph::KnowsSite,
                 crate::entrypoint::webgraph_server::ScoredSite,
+
+                autosuggest::Suggestion,
+                fact_check::FactCheckParams,
+                fact_check::FactCheckResponse,
+
+                crate::alice::SimplifiedWebsite,
+                crate::alice::ExecutionState,
+                crate::alice::EncodedEncryptedState,
+                alice::EncodedSavedState,
             ),
         ),
         modifiers(&ApiModifier),

--- a/core/src/entrypoint/alice.rs
+++ b/core/src/entrypoint/alice.rs
@@ -83,7 +83,7 @@ pub async fn save_state(
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct Params {
+pub struct AliceParams {
     pub message: String,
     pub optic: Option<String>,
     pub prev_state: Option<uuid::Uuid>,
@@ -91,7 +91,7 @@ pub struct Params {
 
 pub async fn route(
     extract::State(state): extract::State<Arc<State>>,
-    extract::Query(params): extract::Query<Params>,
+    extract::Query(params): extract::Query<AliceParams>,
 ) -> std::result::Result<
     Sse<impl Stream<Item = std::result::Result<Event, Infallible>>>,
     http::StatusCode,


### PR DESCRIPTION
This adds:
- Auto-suggest
- Summarize
- Fact check
- Alice

... and all of the necessary types to support them.

Additionally it adds permissive CORS to these routes. This might not be appropriate, or perhaps it should be configurable.

During generation of OpenAPI, types and routes are lifted to the same module, so these exposed types and endpoints needs to have globally unique names. To solve this, a few of the items have been prefixed with the name of the module. Perhaps this should be done to all of the items in a consistent matter.