### PR TITLE
url encode query when send to matching banghit

### DIFF
--- a/core/src/bangs.rs
+++ b/core/src/bangs.rs
@@ -118,24 +118,23 @@ impl Bangs {
             }
         }) {
             if let Some(bang) = self.bangs.get(possible_bang) {
-                let mut url = bang.url.replace(
-                    "{{{s}}}",
-                    intersperse(
-                        terms
-                            .iter()
-                            .filter(|term| {
-                                if let Term::PossibleBang(bang) = term.as_ref() {
-                                    bang != possible_bang
-                                } else {
-                                    true
-                                }
-                            })
-                            .map(|term| term.as_ref().to_string()),
-                        " ".to_string(),
-                    )
-                    .collect::<String>()
-                    .as_str(),
-                );
+                let query = intersperse(
+                    terms
+                        .iter()
+                        .filter(|term| {
+                            if let Term::PossibleBang(bang) = term.as_ref() {
+                                bang != possible_bang
+                            } else {
+                                true
+                            }
+                        })
+                        .map(|term| term.as_ref().to_string()),
+                    " ".to_string(),
+                )
+                .collect::<String>();
+
+                let query = urlencoding::encode(query.as_str()).to_string();
+                let mut url = bang.url.replace("{{{s}}}", query.as_str());
 
                 if !url.contains("://") {
                     url = "http://".to_string() + url.as_str();


### PR DESCRIPTION
fixes #82.
As stated in the issue, queries were not correctly url encoded when they were sent to the matching bang site. This should now be fixed.