### PR TITLE
Add spell-checking CI

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,0 +1,21 @@
+name: Spelling
+
+permissions:
+  contents: read
+
+on: [pull_request]
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CLICOLOR: 1
+
+jobs:
+  spelling:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v3
+    - name: Spell Check Repo
+      uses: crate-ci/typos@master

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,20 @@
+[files]
+extend-exclude = [
+    "*.dat",
+    "*.optic",
+    "*.srx",
+    "*.min.js",
+    "testcases",
+    "stopwords",
+    "spell_checker.rs",
+    "generate_nsfw_dataset.py",
+]
+
+[default.extend-identifiers]
+# common danish worlds
+som = "som"
+ned = "ned"
+alle = "alle"
+# top-level domains
+ba = "ba"
+fo = "fo"


### PR DESCRIPTION
This adds spell checking using [typos](https://github.com/crate-ci/typos/tree/master) as a GitHub Workflow.

The repository includes many files with intentional _English_ spelling mistakes, so these have been excluded by `typos.toml`. As new files with intentional typos are added, this file should be updated as well.