### PR TITLE
Move all `injectGlobal` into components

### DIFF
--- a/frontend/components/Markdown.tsx
+++ b/frontend/components/Markdown.tsx
@@ -2,15 +2,15 @@ import { render } from "https://deno.land/x/gfm@0.2.5/mod.ts";
 import { injectGlobal } from "https://esm.sh/@twind/core@1.1.3";
 
 export const Markdown = ({ src }: { src: string }) => {
+  injectGlobal`
+    .prose .anchor {
+      @apply hidden;
+    }
+  `;
+
   return (
     <div
       dangerouslySetInnerHTML={{ __html: render(src) }}
     />
   );
 };
-
-injectGlobal`
-.prose .anchor {
-    @apply hidden;
-}
-`;

--- a/frontend/islands/Snippet.tsx
+++ b/frontend/islands/Snippet.tsx
@@ -3,13 +3,7 @@ import * as search from "../search/index.ts";
 import { summarySignals } from "../search/summary.ts";
 import { HiHandThumbUpOutline } from "../icons/HiHandThumbUpOutline.tsx";
 import { HiCheck } from "../icons/HiCheck.tsx";
-import {
-  animation,
-  injectGlobal,
-  keyframes,
-  tx,
-} from "https://esm.sh/@twind/core@1.1.3";
-import { IS_BROWSER } from "$fresh/runtime.ts";
+import { injectGlobal } from "https://esm.sh/@twind/core@1.1.3";
 
 const SAMPLE_SUMMARY = {
   inProgress: true,
@@ -18,6 +12,14 @@ const SAMPLE_SUMMARY = {
 };
 
 export const Snippet = ({ item }: { item: search.Webpage }) => {
+  injectGlobal`
+    @keyframes blink {
+      0% {
+        opacity: 0;
+      }
+    }
+  `;
+
   const summary = summarySignals.value[item.url];
 
   return (
@@ -94,16 +96,6 @@ export const Snippet = ({ item }: { item: search.Webpage }) => {
     </div>
   );
 };
-
-if (!IS_BROWSER) {
-  injectGlobal`
-    @keyframes blink {
-      0% {
-        opacity: 0;
-      }
-    }
-  `;
-}
 
 const StackOverflowQA = (
   { answers, question }: {

--- a/frontend/islands/chat/Chat.tsx
+++ b/frontend/islands/chat/Chat.tsx
@@ -462,21 +462,7 @@ const ChatInput = (
   );
 };
 
-const ChatBubble = () => (
-  <div class="flex items-center space-x-1">
-    {Array.from({ length: 3 }).map((_, idx) => (
-      <div
-        class={"dot h-2 w-2 bg-brand/70 rounded-full"}
-        style={{
-          animation: "mercuryTypingAnimation 1.8s infinite ease-in-out",
-          animationDelay: `${200 + idx * 100}ms`,
-        }}
-      />
-    ))}
-  </div>
-);
-
-if (!IS_BROWSER) {
+const ChatBubble = () => {
   injectGlobal`
 @keyframes mercuryTypingAnimation {
   0% {
@@ -493,4 +479,18 @@ if (!IS_BROWSER) {
   }
 }
 `;
-}
+
+  return (
+    <div class="flex items-center space-x-1">
+      {Array.from({ length: 3 }).map((_, idx) => (
+        <div
+          class={"dot h-2 w-2 bg-brand/70 rounded-full"}
+          style={{
+            animation: "mercuryTypingAnimation 1.8s infinite ease-in-out",
+            animationDelay: `${200 + idx * 100}ms`,
+          }}
+        />
+      ))}
+    </div>
+  );
+};

--- a/frontend/routes/_app.tsx
+++ b/frontend/routes/_app.tsx
@@ -3,6 +3,61 @@ import { injectGlobal } from "https://esm.sh/@twind/core@1.1.3";
 import { DefaultCSP } from "../search/utils.ts";
 
 export default function App({ Component }: AppProps) {
+  injectGlobal`
+    html,
+    body {
+      position: relative;
+      width: 100%;
+      height: 100%;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    label {
+      display: block;
+    }
+
+    input:disabled {
+      color: #ccc;
+    }
+
+    button {
+      color: #333;
+      background-color: #f4f4f4;
+      outline: none;
+    }
+
+    button:disabled {
+      color: #999;
+    }
+
+    button:not(:disabled):active {
+      background-color: #ddd;
+    }
+
+    button:focus {
+      border-color: #666;
+    }
+
+    pre > code {
+      font-size: 0.8rem;
+    }
+
+    @media (scripting: none) {
+      .script-none:hidden {
+        @apply hidden;
+      }
+    }
+
+    @media (scripting: initial-only) {
+    }
+
+    @media (scripting: enabled) {
+    }
+  `;
+
   return (
     <>
       <DefaultCSP />
@@ -38,58 +93,3 @@ export default function App({ Component }: AppProps) {
     </>
   );
 }
-
-injectGlobal`
-html,
-body {
-  position: relative;
-  width: 100%;
-  height: 100%;
-}
-
-a:hover {
-  text-decoration: underline;
-}
-
-label {
-  display: block;
-}
-
-input:disabled {
-  color: #ccc;
-}
-
-button {
-  color: #333;
-  background-color: #f4f4f4;
-  outline: none;
-}
-
-button:disabled {
-  color: #999;
-}
-
-button:not(:disabled):active {
-  background-color: #ddd;
-}
-
-button:focus {
-  border-color: #666;
-}
-
-pre > code {
-  font-size: 0.8rem;
-}
-
-@media (scripting: none) {
-  .script-none:hidden {
-    @apply hidden;
-  }
-}
-
-@media (scripting: initial-only) {
-}
-
-@media (scripting: enabled) {
-}
-`;

--- a/frontend/routes/search.tsx
+++ b/frontend/routes/search.tsx
@@ -1,4 +1,4 @@
-import { defineRoute, RouteContext } from "$fresh/server.ts";
+import { defineRoute } from "$fresh/server.ts";
 import { Searchbar } from "../islands/Searchbar.tsx";
 import { injectGlobal } from "https://esm.sh/@twind/core@1.1.3";
 import * as search from "../search/index.ts";
@@ -62,6 +62,30 @@ const extractSearchParams = (searchParams: URLSearchParams): SearchParams => {
 };
 
 export default defineRoute(async (_req, ctx) => {
+  injectGlobal`
+    .search-content {
+      text-rendering: optimizeLegibility;
+      font-smooth: always;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    .change-page-inactive {
+      @apply w-6 text-gray-500;
+    }
+
+    .change-page-active {
+      @apply w-6 text-brand/80 hover:text-brand;
+    }
+
+    .text-snippet {
+      font-weight: 400;
+    }
+    .text-snippet > b {
+      font-weight: 700;
+    }
+  `;
+
   const selected = signal<SelectedAdjust>(null);
 
   const {
@@ -206,30 +230,6 @@ export default defineRoute(async (_req, ctx) => {
     </>
   );
 });
-
-injectGlobal`
-.search-content {
-  text-rendering: optimizeLegibility;
-  font-smooth: always;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-.change-page-inactive {
-  @apply w-6 text-gray-500;
-}
-
-.change-page-active {
-  @apply w-6 text-brand/80 hover:text-brand;
-}
-
-.text-snippet {
-  font-weight: 400;
-}
-.text-snippet > b {
-  font-weight: 700;
-}
-`;
 
 /**
  * Fetces the given `opticUrl` if allowed. The rules for which are allowed


### PR DESCRIPTION
Turns out they cannot be called from a global context when running `deno run -A main.ts` since twind is not setup by the time the files are loaded.

Fortunately, it turns out that the `injectGlobal` does not duplicate the CSS for every component it is rendered in!