### PR TITLE
Don't animate search results when the query changes

### DIFF
--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -191,7 +191,7 @@
 
       {#if results.webpages}
         <div class="grid grid-cols-1 space-y-10 place-self-start">
-          {#each results.webpages as webpage, resultIndex (webpage.url)}
+          {#each results.webpages as webpage, resultIndex (`${query}-${webpage.url}`)}
             <div animate:flip={{ duration: 150 }}>
               <Result {webpage} {resultIndex} on:modal={openSearchModal(webpage)} />
             </div>


### PR DESCRIPTION
Only animate when SR changes, such as when a site is blocked