### PR TITLE
Change many icons for their mini variant

### DIFF
--- a/frontend/src/lib/components/Callout.svelte
+++ b/frontend/src/lib/components/Callout.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import type { ComponentType } from 'svelte';
-  import XMark from '~icons/heroicons/x-mark';
-  import InformationCircle from '~icons/heroicons/information-circle';
-  import CheckCircle from '~icons/heroicons/check-circle';
-  import ExclamationCircle from '~icons/heroicons/exclamation-circle';
-  import Fire from '~icons/heroicons/fire';
+  import InformationCircle from '~icons/heroicons/information-circle-20-solid';
+  import CheckCircle from '~icons/heroicons/check-circle-20-solid';
+  import ExclamationCircle from '~icons/heroicons/exclamation-circle-20-solid';
+  import Fire from '~icons/heroicons/fire-20-solid';
   import { twJoin } from 'tailwind-merge';
 
   export let kind: 'info' | 'success' | 'warning' | 'error' | 'neutral';

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import IconGitHub from '~icons/simple-icons/github';
   import IconDiscord from '~icons/simple-icons/discord';
-  import Bars2 from '~icons/heroicons/bars-2';
+  import Bars2 from '~icons/heroicons/bars-2-20-solid';
 
   import { twJoin } from 'tailwind-merge';
   import { page } from '$app/stores';

--- a/frontend/src/routes/components/+page.svelte
+++ b/frontend/src/routes/components/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import IconGitHub from '~icons/simple-icons/github';
   import IconDiscord from '~icons/simple-icons/discord';
-  import HandThumbUp from '~icons/heroicons/hand-thumb-up-solid';
+  import HandThumbUp from '~icons/heroicons/hand-thumb-up-20-solid';
   import Button from '$lib/components/Button.svelte';
   import Callout from '$lib/components/Callout.svelte';
   import Link from '$lib/components/Link.svelte';

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import HandThumbDown from '~icons/heroicons/hand-thumb-down-solid';
-  import HandThumbUp from '~icons/heroicons/hand-thumb-up-solid';
-  import NoSymbol from '~icons/heroicons/no-symbol-solid';
-  import ChevronLeft from '~icons/heroicons/chevron-left';
-  import ChevronRight from '~icons/heroicons/chevron-right';
+  import HandThumbDown from '~icons/heroicons/hand-thumb-down-20-solid';
+  import HandThumbUp from '~icons/heroicons/hand-thumb-up-20-solid';
+  import NoSymbol from '~icons/heroicons/no-symbol-20-solid';
+  import ChevronLeft from '~icons/heroicons/chevron-left-20-solid';
+  import ChevronRight from '~icons/heroicons/chevron-right-20-solid';
   import OpticSelector from '$lib/components/OpticSelector.svelte';
   import Searchbar from '$lib/components/Searchbar.svelte';
   import type { PageData } from './$types';
@@ -122,7 +122,7 @@
         Do you like results from {modal.site.domain}?
       </h2>
       <div class="flex justify-center space-x-1.5 pt-2">
-        {#each rankingChoices as { ranking, kind, Icon } (ranking)}
+        {#each rankingChoices as { ranking, kind, Icon }}
           <Button
             {kind}
             pale={$siteRankingsStore[modal.site.domain] != ranking}

--- a/frontend/src/routes/search/Discussions.svelte
+++ b/frontend/src/routes/search/Discussions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import ChevronDown from '~icons/heroicons/chevron-down';
-  import ChatBubbleLeftRight from '~icons/heroicons/chat-bubble-left-right';
+  import ChatBubbleLeftRight from '~icons/heroicons/chat-bubble-left-right-20-solid';
   import type { Webpage } from '$lib/api';
   import TextSnippet from '$lib/components/TextSnippet.svelte';
   import Button from '$lib/components/Button.svelte';
@@ -14,7 +14,7 @@
 
 <div class="flex flex-col space-y-1.5 overflow-hidden">
   <div class="flex items-center space-x-1 text-lg">
-    <ChatBubbleLeftRight class="text-sm" />
+    <ChatBubbleLeftRight class="text-sm text-neutral" />
     <span>Discussions</span>
   </div>
   <div class="flex flex-col">

--- a/frontend/src/routes/search/Summary.svelte
+++ b/frontend/src/routes/search/Summary.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import XMark from '~icons/heroicons/x-mark';
+  import XMark from '~icons/heroicons/x-mark-20-solid';
   import Callout from '$lib/components/Callout.svelte';
   import { createEventDispatcher } from 'svelte';
 

--- a/frontend/src/routes/settings/optics/+page.svelte
+++ b/frontend/src/routes/settings/optics/+page.svelte
@@ -4,7 +4,6 @@
   import { opticsStore } from '$lib/stores';
   import { DEFAULT_OPTICS, fetchRemoteOptic, type OpticOption } from '$lib/optics';
   import { derived } from 'svelte/store';
-  import { slide } from 'svelte/transition';
   import Callout from '$lib/components/Callout.svelte';
 
   let name = '';


### PR DESCRIPTION
A lot of places where we use icons they are quite small, so it is preferable to use the mini aka 20x20 solid variants for readability.

Most of the changed icons were already solid, but the following were changed from outline to solid:
- Callout icons
- Discussion chat bubble