### PR TITLE
"Explore page" a11y

### DIFF
--- a/frontend/src/lib/components/Callout.svelte
+++ b/frontend/src/lib/components/Callout.svelte
@@ -29,17 +29,21 @@
 >
   <div>
     <slot name="title">
-      <div class="flex items-center space-x-1.5 pb-1 font-bold capitalize tracking-wide">
+      <div class="flex items-center space-x-1.5 font-bold capitalize tracking-wide">
         <svelte:component this={icon} />
         <span>
           {title}
         </span>
-        <div class="m-0 flex-1" />
-        <slot name="top-right" />
+        {#if $$slots['top-right']}
+          <div class="m-0 flex-1" />
+          <slot name="top-right" />
+        {/if}
       </div>
     </slot>
   </div>
-  <div class="pt-1">
-    <slot />
-  </div>
+  {#if $$slots.default}
+    <div class="mt-1 pt-1">
+      <slot />
+    </div>
+  {/if}
 </div>


### PR DESCRIPTION
Closes #94.

We still need to the following:
- [ ] Handle cancellation.
- [ ] Perhaps disable input while validating?
    - This might be a good idea, since we clear the input when validation succeeds, which would perhaps _clear the users new input_, which we don't like.
- [x] Rebase on `main` when #105 merges.
- [ ] Remove artificial delay, useful for debugging.