### PR TITLE
Do `'*'` replacement `'•'` on the frontend

### DIFF
--- a/core/src/entity_index/mod.rs
+++ b/core/src/entity_index/mod.rs
@@ -218,10 +218,12 @@ impl EntityIndex {
 
         info.into_iter()
             .map(|(key, mut value)| {
-                value.text = value.text.replace('*', "•");
-
-                if let Some((_, rest)) = value.text.split_once('•') {
-                    value.text = rest.to_string();
+                if let Some(start) = value.text.find(|c: char| !(c.is_whitespace() || c == '*')) {
+                    value.text.replace_range(0..start, "");
+                    for link in &mut value.links {
+                        link.start = link.start.saturating_sub(start);
+                        link.end = link.end.saturating_sub(start);
+                    }
                 }
 
                 (key.replace('_', " "), value)

--- a/frontend/src/lib/components/EntitySnippet.svelte
+++ b/frontend/src/lib/components/EntitySnippet.svelte
@@ -8,6 +8,6 @@
   {#if fragment.kind == 'normal'}
     {fragment.text}
   {:else if fragment.kind == 'link'}
-    {' '}<a href={fragment.href} class="hover:underline">{fragment.text}</a>
+    {' '}<a href={fragment.href} class="hover:underline">{fragment.text.replaceAll('*', '•')}</a>
   {/if}
 {/each}


### PR DESCRIPTION
The old version of `EntityIndex::best_info` manipulated the text of spans without alterting the associated link offsets. To do this would be convoluted when having to consider `'•'`, so instead we do not replace `'*'` with `'•'` any longer, but only strip the prefix of `'*'` and whitespace and then subtract the removed prefix length from all link offsets. When rendering the snippets on the frontend, we perform the `'*'` replacement since the index have been made into snippets and the text is thus free to change.