### PR TITLE
Remove all instances of `AsRef<Path>` to reduce the amount of generated code

### DIFF
--- a/core/benches/abstractive-summarizer.rs
+++ b/core/benches/abstractive-summarizer.rs
@@ -2,8 +2,9 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use stract::summarizer::{AbstractiveModel, AbstractiveSummarizer};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let model =
-        AbstractiveSummarizer::new(AbstractiveModel::open("data/abstractive_summary").unwrap());
+    let model = AbstractiveSummarizer::new(
+        AbstractiveModel::open("data/abstractive_summary".as_ref()).unwrap(),
+    );
 
     let text = r#"Aristotle (/ˈærɪstɒtəl/;[1] Greek: Ἀριστοτέλης Aristotélēs, pronounced [aristotélɛːs]; 384–322 BC) was an Ancient Greek philosopher and polymath. His writings cover a broad range of subjects including physics, biology, zoology, metaphysics, logic, ethics, aesthetics, poetry, drama, music, rhetoric, psychology, linguistics, economics, politics, meteorology, geology, and government. As the founder of the Peripatetic school of philosophy in the Lyceum in Athens, he began the wider Aristotelian tradition that followed, which set the groundwork for the development of modern science.
         Little is known about Aristotle's life. He was born in the city of Stagira in Northern Greece during the Classical period. His father, Nicomachus, died when Aristotle was a child, and he was brought up by a guardian. At seventeen or eighteen years of age he joined Plato's Academy in Athens and remained there until the age of thirty-seven (c. 347 BC). Shortly after Plato died, Aristotle left Athens and, at the request of Philip II of Macedon, tutored his son Alexander the Great beginning in 343 BC. He established a library in the Lyceum which helped him to produce many of his hundreds of books on papyrus scrolls.

--- a/core/benches/build-similarity.rs
+++ b/core/benches/build-similarity.rs
@@ -4,7 +4,7 @@ use stract::{ranking::inbound_similarity::InboundSimilarity, webgraph::WebgraphB
 const WEBGRAPH_PATH: &str = "data/webgraph";
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let graph = WebgraphBuilder::new(WEBGRAPH_PATH).open();
+    let graph = WebgraphBuilder::new(WEBGRAPH_PATH.as_ref()).open();
 
     c.bench_function("Inbound similarity creation", |b| {
         b.iter(|| {

--- a/core/benches/harmonic-centrality.rs
+++ b/core/benches/harmonic-centrality.rs
@@ -4,7 +4,7 @@ use stract::webgraph::{centrality::harmonic::HarmonicCentrality, WebgraphBuilder
 const WEBGRAPH_PATH: &str = "data/webgraph";
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let webgraph = WebgraphBuilder::new(WEBGRAPH_PATH).open();
+    let webgraph = WebgraphBuilder::new(WEBGRAPH_PATH.as_ref()).open();
     c.bench_function("Harmonic centrality calculation", |b| {
         b.iter(|| {
             for _ in 0..10 {

--- a/core/benches/search-preindexed-optic.rs
+++ b/core/benches/search-preindexed-optic.rs
@@ -28,7 +28,7 @@ macro_rules! bench {
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let index = Index::open(INDEX_PATH).unwrap();
+    let index = Index::open(INDEX_PATH.as_ref()).unwrap();
     let searcher = LocalSearcher::new(index);
     let optic = include_str!("../../optics/testcases/samples/discussions.optic");
 

--- a/core/benches/search-preindexed.rs
+++ b/core/benches/search-preindexed.rs
@@ -39,10 +39,10 @@ macro_rules! bench {
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let index = Index::open(INDEX_PATH).unwrap();
+    let index = Index::open(INDEX_PATH.as_ref()).unwrap();
     let mut searcher = LocalSearcher::new(index);
     searcher.set_inbound_similarity(
-        InboundSimilarity::open(Path::new(CENTRALITY_PATH).join("inbound_similarity")).unwrap(),
+        InboundSimilarity::open(&Path::new(CENTRALITY_PATH).join("inbound_similarity")).unwrap(),
     );
 
     for _ in 0..1000 {

--- a/core/benches/similar-sites.rs
+++ b/core/benches/similar-sites.rs
@@ -10,8 +10,8 @@ const WEBGRAPH_PATH: &str = "data/webgraph";
 const INBOUND_SIMILARITY_PATH: &str = "data/centrality/inbound_similarity";
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let webgraph = Arc::new(WebgraphBuilder::new(WEBGRAPH_PATH).open());
-    let inbound = InboundSimilarity::open(INBOUND_SIMILARITY_PATH).unwrap();
+    let webgraph = Arc::new(WebgraphBuilder::new(WEBGRAPH_PATH.as_ref()).open());
+    let inbound = InboundSimilarity::open(INBOUND_SIMILARITY_PATH.as_ref()).unwrap();
 
     let finder = SimilarSitesFinder::new(
         webgraph,

--- a/core/benches/spell-correction.rs
+++ b/core/benches/spell-correction.rs
@@ -22,7 +22,7 @@ macro_rules! bench {
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let index = Index::open(INDEX_PATH).unwrap();
+    let index = Index::open(INDEX_PATH.as_ref()).unwrap();
     let spell = Spell::for_index(&index);
 
     for _ in 0..100 {

--- a/core/examples/alice.rs
+++ b/core/examples/alice.rs
@@ -18,7 +18,7 @@ async fn main() {
         .unwrap();
 
     let model = Alice::open(
-        "data/alice",
+        "data/alice".as_ref(),
         Some(AcceleratorConfig {
             layer_fraction: 1.0,
             quantize_fraction: 0.0,

--- a/core/examples/print_inbound_links.rs
+++ b/core/examples/print_inbound_links.rs
@@ -20,8 +20,8 @@ use stract::{
 };
 
 pub fn main() {
-    let graph = WebgraphBuilder::new("data/webgraph").open();
-    let inbound = InboundSimilarity::open("data/centrality/inbound_similarity").unwrap();
+    let graph = WebgraphBuilder::new("data/webgraph".as_ref()).open();
+    let inbound = InboundSimilarity::open("data/centrality/inbound_similarity".as_ref()).unwrap();
 
     for host in ["www.homedepot.com"] {
         println!("{host}:");

--- a/core/examples/print_similar_sites.rs
+++ b/core/examples/print_similar_sites.rs
@@ -39,8 +39,9 @@ fn print_top_nodes(liked_sites: &[&str], top_n: usize, similarity_finder: &Simil
 
 pub fn main() {
     const TOP_N: usize = 50;
-    let graph = WebgraphBuilder::new("data/webgraph").open();
-    let inbound_similarity = InboundSimilarity::open("data/centrality/inbound_similarity").unwrap();
+    let graph = WebgraphBuilder::new("data/webgraph".as_ref()).open();
+    let inbound_similarity =
+        InboundSimilarity::open("data/centrality/inbound_similarity".as_ref()).unwrap();
 
     let similarity_finder = SimilarSitesFinder::new(
         graph.into(),

--- a/core/src/alice/mod.rs
+++ b/core/src/alice/mod.rs
@@ -259,13 +259,13 @@ impl From<AliceAcceleratorConfig> for AcceleratorConfig {
 }
 
 impl Alice {
-    pub fn open<P: AsRef<Path>>(
-        folder: P,
+    pub fn open(
+        folder: &Path,
         accelerator: Option<AcceleratorConfig>,
         encryption_key: &[u8],
     ) -> Result<Alice> {
         let encryption_key = *Key::<Aes256Gcm>::from_slice(encryption_key);
-        let mut model = RawModel::open(folder.as_ref().join("model.safetensors"))?;
+        let mut model = RawModel::open(&folder.join("model.safetensors"))?;
 
         if let Some(accelerator) = accelerator {
             model.load_to_device(
@@ -277,7 +277,7 @@ impl Alice {
         }
 
         let inner = Rc::new(model);
-        let tokenizer = Arc::new(Tokenizer::open(folder.as_ref().join("tokenizer.json"))?);
+        let tokenizer = Arc::new(Tokenizer::open(&folder.join("tokenizer.json"))?);
 
         let end_tokens = vec![tokenizer.tokenizer.token_to_id("<|endoftext|>").unwrap() as i64];
 
@@ -369,7 +369,7 @@ pub struct Tokenizer {
 }
 
 impl Tokenizer {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Tokenizer> {
+    pub fn open(path: &Path) -> Result<Tokenizer> {
         let tokenizer = tokenizers::Tokenizer::from_file(path).map_err(|e| anyhow!(e))?;
 
         Ok(Self { tokenizer })

--- a/core/src/alice/raw_model.rs
+++ b/core/src/alice/raw_model.rs
@@ -521,7 +521,7 @@ pub struct RawModel {
 }
 
 impl RawModel {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<RawModel> {
+    pub fn open(path: &Path) -> Result<RawModel> {
         // SAFETY
         // broadcasting: please don't modify the file while we're reading it.
         let mmap = unsafe {

--- a/core/src/api/mod.rs
+++ b/core/src/api/mod.rs
@@ -104,10 +104,10 @@ pub async fn favicon() -> impl IntoResponse {
 }
 
 pub async fn router(config: &ApiConfig, counters: Counters) -> Result<Router> {
-    let autosuggest = Autosuggest::load_csv(&config.queries_csv_path)?;
+    let autosuggest = Autosuggest::load_csv(config.queries_csv_path.as_ref())?;
 
     let lambda_model = match &config.lambda_model_path {
-        Some(path) => Some(LambdaMART::open(path)?),
+        Some(path) => Some(LambdaMART::open(path.as_ref())?),
         None => None,
     };
 
@@ -117,7 +117,7 @@ pub async fn router(config: &ApiConfig, counters: Counters) -> Result<Router> {
         query_store_queue
     });
 
-    let bangs = Bangs::from_path(&config.bangs_path);
+    let bangs = Bangs::from_path(config.bangs_path.as_ref());
 
     let cluster = Arc::new(
         Cluster::join(
@@ -136,12 +136,12 @@ pub async fn router(config: &ApiConfig, counters: Counters) -> Result<Router> {
     let state = {
         let mut cross_encoder = None;
 
-        if let Some(path) = config.crossencoder_model_path.as_ref() {
-            cross_encoder = Some(CrossEncoderModel::open(path)?);
+        if let Some(path) = &config.crossencoder_model_path {
+            cross_encoder = Some(CrossEncoderModel::open(path.as_ref())?);
         }
 
         let qa_model = match &config.qa_model_path {
-            Some(path) => Some(QaModel::open(path)?),
+            Some(path) => Some(QaModel::open(path.as_ref())?),
             None => None,
         };
 
@@ -160,7 +160,7 @@ pub async fn router(config: &ApiConfig, counters: Counters) -> Result<Router> {
             autosuggest,
             counters,
             remote_webgraph,
-            summarizer: Arc::new(Summarizer::open(&config.summarizer_path)?),
+            summarizer: Arc::new(Summarizer::open(config.summarizer_path.as_ref())?),
             improvement_queue: query_store_queue,
             cluster,
         })

--- a/core/src/autosuggest.rs
+++ b/core/src/autosuggest.rs
@@ -29,7 +29,7 @@ pub struct Autosuggest {
 }
 
 impl Autosuggest {
-    pub fn load_csv<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub fn load_csv(path: &Path) -> Result<Self> {
         let mut queries: Vec<String> = Vec::new();
 
         let mut rdr = csv::Reader::from_path(path)?;

--- a/core/src/bangs.rs
+++ b/core/src/bangs.rs
@@ -92,7 +92,7 @@ pub struct Bangs {
 }
 
 impl Bangs {
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Self {
+    pub fn from_path(path: &Path) -> Self {
         let json = fs::read_to_string(path).unwrap();
 
         Self::from_json(json.as_str())

--- a/core/src/crawler/coordinator.rs
+++ b/core/src/crawler/coordinator.rs
@@ -22,7 +22,7 @@ pub struct CrawlCoordinator {
 }
 
 impl CrawlCoordinator {
-    pub fn new<P: AsRef<Path>>(jobs_queue: P) -> Result<Self> {
+    pub fn new(jobs_queue: &Path) -> Result<Self> {
         Ok(Self {
             jobs: Mutex::new(FileQueue::new(jobs_queue)?),
         })

--- a/core/src/crawler/planner.rs
+++ b/core/src/crawler/planner.rs
@@ -76,21 +76,21 @@ fn check_config(config: &CrawlPlannerConfig) -> Result<()> {
     Ok(())
 }
 
-pub fn make_crawl_plan<P: AsRef<Path>>(
+pub fn make_crawl_plan(
     host_centrality: RocksDbStore<NodeID, f64>,
     page_centrality: RocksDbStore<NodeID, f64>,
     host_graph: Webgraph,
     page_graph: Webgraph,
     config: CrawlPlannerConfig,
-    output: P,
+    output: &Path,
 ) -> Result<()> {
     check_config(&config)?;
 
-    if output.as_ref().exists() {
+    if output.exists() {
         return Err(anyhow!("output path already exists"));
     }
 
-    let queue_path = output.as_ref().join("job_queue");
+    let queue_path = output.join("job_queue");
     std::fs::create_dir_all(&queue_path)?;
 
     let hosts = top_hosts(
@@ -103,7 +103,7 @@ pub fn make_crawl_plan<P: AsRef<Path>>(
     let job_queues: Vec<Mutex<FileQueueWriter<Job>>> = (0..config.num_job_queues)
         .map(|i| {
             let path = queue_path.join(format!("{}.queue", i));
-            FileQueueWriter::new(path)
+            FileQueueWriter::new(&path)
         })
         .collect::<Result<Vec<_>>>()?
         .into_iter()
@@ -188,7 +188,7 @@ pub fn make_crawl_plan<P: AsRef<Path>>(
         stats: stats.into_inner().unwrap_or_else(|e| e.into_inner()),
     };
 
-    let metadata_path = output.as_ref().join("metadata.json");
+    let metadata_path = output.join("metadata.json");
 
     let metadata_file = std::fs::File::create(metadata_path)?;
     serde_json::to_writer_pretty(metadata_file, &metadata)?;

--- a/core/src/entity_index/mod.rs
+++ b/core/src/entity_index/mod.rs
@@ -163,13 +163,13 @@ pub struct EntityMatch {
 }
 
 impl EntityIndex {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
-        if !path.as_ref().exists() {
-            fs::create_dir_all(path.as_ref())?;
+    pub fn open(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            fs::create_dir_all(path)?;
         }
 
         let schema = schema();
-        let tv_path = path.as_ref().join("inverted_index");
+        let tv_path = path.join("inverted_index");
         let tantivy_index = if tv_path.exists() {
             tantivy::Index::open_in_dir(&tv_path)?
         } else {
@@ -177,9 +177,8 @@ impl EntityIndex {
             tantivy::Index::create_in_dir(&tv_path, schema.clone())?
         };
 
-        let attribute_occurrences = Box::new(RocksDbStore::open(
-            path.as_ref().join("attribute_occurrences"),
-        ));
+        let attribute_occurrences =
+            Box::new(RocksDbStore::open(&path.join("attribute_occurrences")));
 
         let stopwords: HashSet<String> = include_str!("../../stopwords/English.txt")
             .lines()
@@ -192,7 +191,7 @@ impl EntityIndex {
             Normal::with_stopwords(stopwords.clone().into_iter().collect()),
         );
 
-        let image_store = EntityImageStore::open(path.as_ref().join("images"));
+        let image_store = EntityImageStore::open(&path.join("images"));
 
         let writer = tantivy_index.writer(10_000_000_000)?;
         let reader = tantivy_index.reader()?;
@@ -486,7 +485,7 @@ mod tests {
 
     #[test]
     fn stopwords_title_ignored() {
-        let mut index = EntityIndex::open(crate::gen_temp_path()).unwrap();
+        let mut index = EntityIndex::open(&crate::gen_temp_path()).unwrap();
 
         index.insert(Entity {
             title: "the ashes".to_string(),

--- a/core/src/entrypoint/alice.rs
+++ b/core/src/entrypoint/alice.rs
@@ -174,7 +174,7 @@ pub async fn run(config: AliceLocalConfig) -> Result<(), anyhow::Error> {
 
     info!("starting alice");
     let alice = Alice::open(
-        &config.alice_path,
+        config.alice_path.as_ref(),
         config.accelerator.clone().map(|acc| acc.into()),
         &key,
     )?;

--- a/core/src/entrypoint/autosuggest_scrape.rs
+++ b/core/src/entrypoint/autosuggest_scrape.rs
@@ -84,8 +84,8 @@ impl FromStr for Gl {
     }
 }
 
-fn save_queries<P: AsRef<Path>>(queries: &HashSet<String>, path: P) -> Result<()> {
-    let mut wtr = Writer::from_path(&path)?;
+fn save_queries(queries: &HashSet<String>, path: &Path) -> Result<()> {
+    let mut wtr = Writer::from_path(path)?;
 
     let mut queries: Vec<_> = queries.iter().collect();
     queries.sort();
@@ -99,11 +99,11 @@ fn save_queries<P: AsRef<Path>>(queries: &HashSet<String>, path: P) -> Result<()
     Ok(())
 }
 
-pub fn run<P: AsRef<Path>>(
+pub fn run(
     queries_to_scrape: usize,
     gl: Gl,
     ms_sleep_between_req: u64,
-    output_dir: P,
+    output_dir: &Path,
 ) -> Result<()> {
     let mut queries = HashSet::new();
     let mut queue = VecDeque::new();
@@ -120,9 +120,7 @@ pub fn run<P: AsRef<Path>>(
         queue.push_back(c.to_string());
     }
 
-    let path = output_dir
-        .as_ref()
-        .join(format!("queries_{:}.csv", gl.to_string().as_str()));
+    let path = output_dir.join(format!("queries_{:}.csv", gl.to_string().as_str()));
 
     let mut queries_since_last_save = 0;
 

--- a/core/src/entrypoint/centrality.rs
+++ b/core/src/entrypoint/centrality.rs
@@ -26,7 +26,7 @@ use crate::{
     },
 };
 
-fn store_csv<P: AsRef<Path>>(data: Vec<(Node, f64)>, output: P) {
+fn store_csv(data: Vec<(Node, f64)>, output: &Path) {
     let csv_file = File::options()
         .write(true)
         .create(true)
@@ -69,11 +69,11 @@ impl Ord for SortableFloat {
 pub struct Centrality;
 
 impl Centrality {
-    pub fn build_harmonic<P: AsRef<Path>>(webgraph_path: P, base_output: P) {
+    pub fn build_harmonic(webgraph_path: &Path, base_output: &Path) {
         tracing::info!("Building harmonic centrality");
         let graph = WebgraphBuilder::new(webgraph_path).open();
         let harmonic_centrality = HarmonicCentrality::calculate(&graph);
-        let store = RocksDbStore::open(base_output.as_ref().join("harmonic"));
+        let store = RocksDbStore::open(&base_output.join("harmonic"));
 
         for (node_id, centrality) in harmonic_centrality.iter() {
             store.insert(*node_id, centrality);
@@ -98,32 +98,31 @@ impl Centrality {
             .map(|(score, id)| (graph.id2node(&id).unwrap(), score.0 .0))
             .collect();
 
-        store_csv(harmonics, base_output.as_ref().join("harmonic.csv"));
+        store_csv(harmonics, &base_output.join("harmonic.csv"));
     }
 
-    pub fn build_similarity<P: AsRef<Path>>(webgraph_path: P, base_output: P) {
+    pub fn build_similarity(webgraph_path: &Path, base_output: &Path) {
         tracing::info!("Building inbound similarity");
         let graph = WebgraphBuilder::new(webgraph_path).open();
 
         let sim = InboundSimilarity::build(&graph);
 
-        sim.save(base_output.as_ref().join("inbound_similarity"))
-            .unwrap();
+        sim.save(&base_output.join("inbound_similarity")).unwrap();
     }
 
-    pub fn build_derived_harmonic<P: AsRef<Path>>(
-        webgraph_path: P,
-        host_centrality_path: P,
-        base_output: P,
+    pub fn build_derived_harmonic(
+        webgraph_path: &Path,
+        host_centrality_path: &Path,
+        base_output: &Path,
     ) -> Result<()> {
         tracing::info!("Building derived harmonic centrality");
         let graph = WebgraphBuilder::new(webgraph_path).single_threaded().open();
-        let host_centrality = RocksDbStore::open(host_centrality_path.as_ref().join("harmonic"));
+        let host_centrality = RocksDbStore::open(&host_centrality_path.join("harmonic"));
 
         let derived = DerivedCentrality::build(
             &host_centrality,
             &graph,
-            base_output.as_ref().join("derived_harmonic"),
+            &base_output.join("derived_harmonic"),
         )?;
 
         let mut top_nodes = BinaryHeap::new();
@@ -144,7 +143,7 @@ impl Centrality {
             .map(|(score, id)| (graph.id2node(&id).unwrap(), score.0 .0))
             .collect();
 
-        store_csv(derived, base_output.as_ref().join("derived_centrality.csv"));
+        store_csv(derived, &base_output.join("derived_centrality.csv"));
 
         Ok(())
     }

--- a/core/src/entrypoint/crawler.rs
+++ b/core/src/entrypoint/crawler.rs
@@ -37,7 +37,7 @@ pub async fn worker(config: config::CrawlerConfig) -> Result<()> {
 }
 
 pub async fn coordinator(config: config::CrawlCoordinatorConfig) -> Result<()> {
-    let coordinator = Arc::new(CrawlCoordinator::new(config.job_queue)?);
+    let coordinator = Arc::new(CrawlCoordinator::new(config.job_queue.as_ref())?);
 
     let addr: SocketAddr = config.host;
     let server = coordinator::CoordinatorService { coordinator }
@@ -67,10 +67,10 @@ pub async fn router(config: config::CrawlRouterConfig) -> Result<()> {
 }
 
 pub fn planner(config: config::CrawlPlannerConfig) -> Result<()> {
-    let page_centrality = RocksDbStore::open(&config.page_harmonic_path);
-    let host_centrality = RocksDbStore::open(&config.host_harmonic_path);
-    let page_graph = WebgraphBuilder::new(&config.page_graph_path).open();
-    let host_graph = WebgraphBuilder::new(&config.host_graph_path).open();
+    let page_centrality = RocksDbStore::open(config.page_harmonic_path.as_ref());
+    let host_centrality = RocksDbStore::open(config.host_harmonic_path.as_ref());
+    let page_graph = WebgraphBuilder::new(config.page_graph_path.as_ref()).open();
+    let host_graph = WebgraphBuilder::new(config.host_graph_path.as_ref()).open();
     let output_path = config.output_path.clone();
 
     make_crawl_plan(
@@ -79,7 +79,7 @@ pub fn planner(config: config::CrawlPlannerConfig) -> Result<()> {
         host_graph,
         page_graph,
         config,
-        output_path,
+        output_path.as_ref(),
     )?;
 
     Ok(())

--- a/core/src/entrypoint/dmoz_parser.rs
+++ b/core/src/entrypoint/dmoz_parser.rs
@@ -122,7 +122,7 @@ impl Page {
     }
 }
 
-pub fn parse<P: AsRef<Path>>(dmoz_file: P) -> Result<human_website_annotations::Mapper> {
+pub fn parse(dmoz_file: &Path) -> Result<human_website_annotations::Mapper> {
     let file = File::open(dmoz_file)?;
     let reader = BufReader::new(file);
     let reader = BufReader::new(MultiGzDecoder::new(reader));
@@ -155,7 +155,7 @@ pub fn parse<P: AsRef<Path>>(dmoz_file: P) -> Result<human_website_annotations::
     Ok(map.into())
 }
 
-pub fn run<P: AsRef<Path>>(dmoz_file: P, output_path: P) -> Result<()> {
+pub fn run(dmoz_file: &Path, output_path: &Path) -> Result<()> {
     let mapper = parse(dmoz_file)?;
     mapper.save(output_path)?;
 

--- a/core/src/entrypoint/entity.rs
+++ b/core/src/entrypoint/entity.rs
@@ -18,6 +18,7 @@ use std::{
     collections::{BTreeMap, HashSet},
     fs::File,
     io::{BufRead, BufReader},
+    path::Path,
 };
 
 use crate::{
@@ -99,7 +100,7 @@ impl<R: BufRead> Iterator for EntityIterator<R> {
 pub struct EntityIndexer;
 
 impl EntityIndexer {
-    pub fn run(wikipedia_dump_path: String, output_path: String) -> Result<()> {
+    pub fn run(wikipedia_dump_path: &Path, output_path: &Path) -> Result<()> {
         let reader = BufReader::new(File::open(wikipedia_dump_path)?);
         let reader = BufReader::new(MultiBzDecoder::new(reader));
         let mut index = EntityIndex::open(output_path)?;

--- a/core/src/entrypoint/safety_classifier.rs
+++ b/core/src/entrypoint/safety_classifier.rs
@@ -22,12 +22,9 @@ use std::path::Path;
 
 const TEST_SIZE: f64 = 0.2;
 
-pub fn train<P: AsRef<Path>>(dataset: P, output: P) -> Result<()> {
-    if !dataset.as_ref().exists() {
-        return Err(anyhow::anyhow!(
-            "dataset path {:?} does not exist",
-            dataset.as_ref()
-        ));
+pub fn train(dataset: &Path, output: &Path) -> Result<()> {
+    if !dataset.exists() {
+        return Err(anyhow::anyhow!("dataset path {:?} does not exist", dataset));
     }
 
     let mut model = webpage::safety_classifier::Model::new();
@@ -55,7 +52,7 @@ pub fn train<P: AsRef<Path>>(dataset: P, output: P) -> Result<()> {
     Ok(())
 }
 
-pub fn predict<P: AsRef<Path>>(model: P, text: &str) -> Result<()> {
+pub fn predict(model: &Path, text: &str) -> Result<()> {
     let model = webpage::safety_classifier::Model::open(model)?;
     let pred = model.predict_text(text);
 

--- a/core/src/entrypoint/search_server.rs
+++ b/core/src/entrypoint/search_server.rs
@@ -61,11 +61,11 @@ impl SearchService {
     async fn new(config: config::SearchServerConfig) -> Result<Self> {
         let entity_index = config
             .entity_index_path
-            .map(|path| EntityIndex::open(path).unwrap());
+            .map(|path| EntityIndex::open(path.as_ref()).unwrap());
         let centrality_store = config
             .host_centrality_store_path
-            .map(|p| InboundSimilarity::open(Path::new(&p).join("inbound_similarity")).unwrap());
-        let search_index = Index::open(config.index_path)?;
+            .map(|p| InboundSimilarity::open(&Path::new(&p).join("inbound_similarity")).unwrap());
+        let search_index = Index::open(config.index_path.as_ref())?;
 
         let mut local_searcher = LocalSearcher::new(search_index);
 
@@ -78,11 +78,11 @@ impl SearchService {
         }
 
         if let Some(model_path) = config.linear_model_path {
-            local_searcher.set_linear_model(LinearRegression::open(model_path)?);
+            local_searcher.set_linear_model(LinearRegression::open(model_path.as_ref())?);
         }
 
         if let Some(model_path) = config.lambda_model_path {
-            local_searcher.set_lambda_model(LambdaMART::open(model_path)?);
+            local_searcher.set_lambda_model(LambdaMART::open(model_path.as_ref())?);
         }
 
         if config.build_spell_dictionary {

--- a/core/src/entrypoint/webgraph.rs
+++ b/core/src/entrypoint/webgraph.rs
@@ -66,7 +66,7 @@ pub struct Job {
     pub warc_paths: Vec<String>,
 }
 
-pub fn open_host_graph_writer<P: AsRef<Path>>(path: P) -> webgraph::WebgraphWriter {
+pub fn open_host_graph_writer(path: &Path) -> webgraph::WebgraphWriter {
     WebgraphWriter::new(
         path,
         crate::executor::Executor::single_thread(),
@@ -74,7 +74,7 @@ pub fn open_host_graph_writer<P: AsRef<Path>>(path: P) -> webgraph::WebgraphWrit
     )
 }
 
-pub fn open_page_graph_writer<P: AsRef<Path>>(path: P) -> webgraph::WebgraphWriter {
+pub fn open_page_graph_writer(path: &Path) -> webgraph::WebgraphWriter {
     WebgraphWriter::new(
         path,
         crate::executor::Executor::single_thread(),
@@ -177,8 +177,8 @@ impl Webgraph {
             let page_path = page_path.join(format!("worker_{i}"));
 
             let mut worker = WebgraphWorker {
-                host_graph: open_host_graph_writer(host_path),
-                page_graph: open_page_graph_writer(page_path),
+                host_graph: open_host_graph_writer(&host_path),
+                page_graph: open_page_graph_writer(&page_path),
             };
 
             let jobs = jobs.clone();

--- a/core/src/entrypoint/webgraph_server.rs
+++ b/core/src/entrypoint/webgraph_server.rs
@@ -191,16 +191,16 @@ pub async fn run(config: config::WebgraphServerConfig) -> Result<()> {
     let searcher = DistributedSearcher::new(cluster);
 
     let host_graph = Arc::new(
-        WebgraphBuilder::new(config.host_graph_path)
+        WebgraphBuilder::new(config.host_graph_path.as_ref())
             .compression(Compression::Lz4)
             .open(),
     );
     let page_graph = Arc::new(
-        WebgraphBuilder::new(config.page_graph_path)
+        WebgraphBuilder::new(config.page_graph_path.as_ref())
             .compression(Compression::Lz4)
             .open(),
     );
-    let inbound_similarity = InboundSimilarity::open(config.inbound_similarity_path)?;
+    let inbound_similarity = InboundSimilarity::open(config.inbound_similarity_path.as_ref())?;
 
     let similar_sites_finder = SimilarSitesFinder::new(
         Arc::clone(&host_graph),

--- a/core/src/feed/index.rs
+++ b/core/src/feed/index.rs
@@ -34,9 +34,9 @@ pub struct FeedIndex {
 }
 
 impl FeedIndex {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
-        if !path.as_ref().exists() {
-            std::fs::create_dir_all(path.as_ref())?;
+    pub fn open(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            std::fs::create_dir_all(path)?;
         }
 
         let url_tokenizer = Tokenizer::SiteOperator(SiteOperatorUrlTokenizer);
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn feed_index() {
-        let mut index = FeedIndex::open(crate::gen_temp_path()).unwrap();
+        let mut index = FeedIndex::open(&crate::gen_temp_path()).unwrap();
 
         let a = Feed {
             url: Url::parse("https://a.com/feed.xml").unwrap(),

--- a/core/src/human_website_annotations.rs
+++ b/core/src/human_website_annotations.rs
@@ -73,7 +73,7 @@ impl From<HashMap<String, Info>> for Mapper {
 }
 
 impl Mapper {
-    pub fn save<P: AsRef<Path>>(self, path: P) -> Result<()> {
+    pub fn save(self, path: &Path) -> Result<()> {
         let mut file = File::options()
             .create(true)
             .truncate(true)
@@ -86,7 +86,7 @@ impl Mapper {
         Ok(())
     }
 
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub fn open(path: &Path) -> Result<Self> {
         let mut reader = BufReader::new(File::open(path)?);
 
         let mut bytes = Vec::new();

--- a/core/src/image_store.rs
+++ b/core/src/image_store.rs
@@ -87,11 +87,11 @@ struct BaseImageStore {
 
 impl BaseImageStore {
     #[cfg(test)]
-    fn open<P: AsRef<Path>>(path: P) -> Self {
+    fn open(path: &Path) -> Self {
         Self::open_with_filters(path, Vec::new())
     }
 
-    fn open_with_filters<P: AsRef<Path>>(path: P, filters: Vec<Box<dyn ImageFilter>>) -> Self {
+    fn open_with_filters(path: &Path, filters: Vec<Box<dyn ImageFilter>>) -> Self {
         let store = Box::new(RocksDbStore::open(path));
 
         Self { store, filters }
@@ -144,7 +144,7 @@ pub struct EntityImageStore {
 }
 
 impl EntityImageStore {
-    pub fn open<P: AsRef<Path>>(path: P) -> Self {
+    pub fn open(path: &Path) -> Self {
         let store = BaseImageStore::open_with_filters(
             path,
             vec![Box::new(ResizeFilter {
@@ -233,7 +233,7 @@ mod tests {
             ImageBuffer::from_pixel(2, 2, image::Rgb::<u16>([u16::MAX, u16::MAX, u16::MAX])).into(),
         );
         let key = "test".to_string();
-        let mut store = BaseImageStore::open(crate::gen_temp_path());
+        let mut store = BaseImageStore::open(&crate::gen_temp_path());
 
         assert_eq!(store.get(&key), None);
         store.insert(key.clone(), image.clone());

--- a/core/src/index.rs
+++ b/core/src/index.rs
@@ -47,23 +47,20 @@ pub struct Index {
 }
 
 impl Index {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
-        if !path.as_ref().exists() {
-            fs::create_dir_all(path.as_ref())?;
+    pub fn open(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            fs::create_dir_all(path)?;
         }
 
-        let inverted_index =
-            InvertedIndex::open(path.as_ref().join(INVERTED_INDEX_SUBFOLDER_NAME))?;
+        let inverted_index = InvertedIndex::open(&path.join(INVERTED_INDEX_SUBFOLDER_NAME))?;
 
-        let region_count = RegionCount::open(path.as_ref().join(REGION_COUNT_FILE_NAME));
+        let region_count = RegionCount::open(&path.join(REGION_COUNT_FILE_NAME));
 
         Ok(Self {
             inverted_index,
             region_count,
-            subdomain_counter: SubdomainCounter::open(
-                path.as_ref().join(SUBDOMAIN_COUNT_SUBFOLDER_NAME),
-            ),
-            path: path.as_ref().to_str().unwrap().to_string(),
+            subdomain_counter: SubdomainCounter::open(&path.join(SUBDOMAIN_COUNT_SUBFOLDER_NAME)),
+            path: path.to_str().unwrap().to_string(),
         })
     }
 
@@ -80,7 +77,7 @@ impl Index {
     #[cfg(test)]
     pub fn temporary() -> Result<Self> {
         let path = crate::gen_temp_path();
-        Self::open(path)
+        Self::open(&path)
     }
 
     pub fn insert(&mut self, webpage: Webpage) -> Result<()> {
@@ -136,7 +133,7 @@ impl Index {
         self.subdomain_counter.merge(other.subdomain_counter);
         drop(self.subdomain_counter);
 
-        Self::open(&self.path).expect("failed to open index")
+        Self::open(self.path.as_ref()).expect("failed to open index")
     }
 
     pub fn schema(&self) -> Arc<Schema> {
@@ -178,7 +175,7 @@ impl From<FrozenIndex> for Index {
         }
 
         directory::recreate_folder(&frozen.root).unwrap();
-        Index::open(path).expect("failed to open index")
+        Index::open(path.as_ref()).expect("failed to open index")
     }
 }
 

--- a/core/src/inverted_index.rs
+++ b/core/src/inverted_index.rs
@@ -112,11 +112,11 @@ pub struct InvertedIndex {
 }
 
 impl InvertedIndex {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub fn open(path: &Path) -> Result<Self> {
         let schema = create_schema();
 
-        let tantivy_index = if path.as_ref().exists() {
-            let mmap_directory = MmapDirectory::open(&path)?;
+        let tantivy_index = if path.exists() {
+            let mmap_directory = MmapDirectory::open(path)?;
             tantivy::Index::open(mmap_directory)?
         } else {
             let index_settings = tantivy::IndexSettings {
@@ -127,8 +127,8 @@ impl InvertedIndex {
                 ..Default::default()
             };
 
-            fs::create_dir_all(&path)?;
-            let mmap_directory = MmapDirectory::open(&path)?;
+            fs::create_dir_all(path)?;
+            let mmap_directory = MmapDirectory::open(path)?;
             tantivy::Index::create(mmap_directory, schema.clone(), index_settings)?
         };
 
@@ -178,7 +178,7 @@ impl InvertedIndex {
             writer,
             reader,
             schema: Arc::new(schema),
-            path: path.as_ref().to_str().unwrap().to_string(),
+            path: path.to_str().unwrap().to_string(),
             tantivy_index,
             snippet_config: SnippetConfig::default(),
         })
@@ -199,7 +199,7 @@ impl InvertedIndex {
     #[cfg(test)]
     pub fn temporary() -> Result<Self> {
         let path = crate::gen_temp_path();
-        Self::open(path)
+        Self::open(&path)
     }
 
     pub fn insert(&self, webpage: Webpage) -> Result<()> {
@@ -474,7 +474,7 @@ impl InvertedIndex {
             .unwrap();
         }
 
-        Self::open(path).expect("failed to open index")
+        Self::open(path.as_ref()).expect("failed to open index")
     }
 
     pub fn stop(self) {

--- a/core/src/kv/rocksdb_store.rs
+++ b/core/src/kv/rocksdb_store.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{fs, marker::PhantomData};
+use std::{fs, marker::PhantomData, path::Path};
 
 use rocksdb::{
     BlockBasedOptions, DBIteratorWithThreadMode, DBWithThreadMode, IteratorMode, Options,
@@ -39,12 +39,9 @@ where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
-    pub fn open<P>(path: P) -> Self
-    where
-        P: AsRef<std::path::Path>,
-    {
-        if !path.as_ref().exists() {
-            fs::create_dir_all(path.as_ref()).expect("faild to create dir");
+    pub fn open(path: &Path) -> Self {
+        if !path.exists() {
+            fs::create_dir_all(path).expect("faild to create dir");
         }
 
         let mut options = Options::default();

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -17,7 +17,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use serde::de::DeserializeOwned;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use stract::config;
 use stract::entrypoint::autosuggest_scrape::{self, Gl};
 
@@ -61,8 +61,8 @@ enum Commands {
     /// Parse the DMOZ dataset. DMOZ contains a list of websites and their categories.
     /// It can be used to calculate the topic centrality for websites or augments website descriptions during indexing.
     DmozParser {
-        dmoz_file: String,
-        output_path: String,
+        dmoz_file: PathBuf,
+        output_path: PathBuf,
     },
 
     /// Webgraph specific commands.
@@ -72,18 +72,18 @@ enum Commands {
     },
 
     /// Deploy the search server.
-    SearchServer { config_path: String },
+    SearchServer { config_path: PathBuf },
 
     /// Deploy the json http api. The api interacts with
     /// the search servers, webgraph servers etc. to provide the necesarry functionality.
-    Api { config_path: String },
+    Api { config_path: PathBuf },
 
     /// Scrape the Google autosuggest API for search queries.
     AutosuggestScrape {
         num_queries: usize,
         gl: Gl,
         ms_sleep_between_req: u64,
-        output_dir: String,
+        output_dir: PathBuf,
     },
 
     /// Deploy the crawler.
@@ -113,18 +113,18 @@ enum Commands {
 enum Crawler {
     /// Deploy the crawl worker. The worker is responsible for downloading webpages, saving them to S3,
     /// and sending newly discovered urls back to the crawl coordinator.
-    Worker { config_path: String },
+    Worker { config_path: PathBuf },
 
     /// Deploy the crawl coordinator. The crawl coordinator is responsible for
     /// distributing crawl jobs to the crawles and deciding which urls to crawl next.
-    Coordinator { config_path: String },
+    Coordinator { config_path: PathBuf },
 
     /// Deploy the crawl router. The crawl router is responsible for routing job responses and requests
     /// from the workers to the correct crawl coordinators.
-    Router { config_path: String },
+    Router { config_path: PathBuf },
 
     /// Create a crawl plan.
-    Plan { config_path: String },
+    Plan { config_path: PathBuf },
 }
 
 /// Commands to train or run inference on the classifier that predicts if a webpage is NSFW or SFW.
@@ -132,62 +132,62 @@ enum Crawler {
 enum SafetyClassifierOptions {
     /// Train the classifier
     Train {
-        dataset_path: String,
-        output_path: String,
+        dataset_path: PathBuf,
+        output_path: PathBuf,
     },
 
     /// Run a single prediction to test the model
-    Predict { model_path: String, text: String },
+    Predict { model_path: PathBuf, text: String },
 }
 
 #[derive(Subcommand)]
 enum CentralityMode {
     /// Calculate metrics for the host webgraph.
     Host {
-        webgraph_path: String,
-        output_path: String,
+        webgraph_path: PathBuf,
+        output_path: PathBuf,
     },
     /// Calculate metrics for the page webgraph.
     Page {
-        webgraph_path: String,
-        host_centrality_path: String,
-        output_path: String,
+        webgraph_path: PathBuf,
+        host_centrality_path: PathBuf,
+        output_path: PathBuf,
     },
 }
 
 #[derive(Subcommand)]
 enum WebgraphOptions {
     /// Create a new webgraph.
-    Create { config_path: String },
+    Create { config_path: PathBuf },
 
     /// Merge multiple webgraphs into a single graph.
     Merge {
         #[clap(required = true)]
-        paths: Vec<String>,
+        paths: Vec<PathBuf>,
     },
 
     /// Deploy the webgraph server. The webgraph server is responsible for serving the webgraph to the search servers.
     /// This is e.g. used to find similar sites etc.
-    Server { config_path: String },
+    Server { config_path: PathBuf },
 }
 
 #[derive(Subcommand)]
 enum IndexingOptions {
     /// Create the search index.
-    Search { config_path: String },
+    Search { config_path: PathBuf },
 
     /// Create the entity index. Used in the sidebar of the search UI.
     Entity {
-        wikipedia_dump_path: String,
-        output_path: String,
+        wikipedia_dump_path: PathBuf,
+        output_path: PathBuf,
     },
 
     /// Merge multiple search indexes into a single index.
     Merge { indexes: Vec<String> },
 }
 
-fn load_toml_config<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> T {
-    let path = path.as_ref();
+fn load_toml_config<T: DeserializeOwned>(path: &Path) -> T {
+    let path = path;
     let raw_config = fs::read_to_string(path)
         .with_context(|| format!("Failed to read config: '{}'", path.display()))
         .unwrap();
@@ -210,13 +210,13 @@ fn main() -> Result<()> {
     match args.command {
         Commands::Indexer { options } => match options {
             IndexingOptions::Search { config_path } => {
-                let config = load_toml_config(config_path);
+                let config = load_toml_config(&config_path);
                 entrypoint::Indexer::run(&config)?;
             }
             IndexingOptions::Entity {
                 wikipedia_dump_path,
                 output_path,
-            } => entrypoint::EntityIndexer::run(wikipedia_dump_path, output_path)?,
+            } => entrypoint::EntityIndexer::run(&wikipedia_dump_path, &output_path)?,
             IndexingOptions::Merge { indexes } => {
                 entrypoint::Indexer::merge(indexes.into_iter().map(IndexPointer::from).collect())?
             }
@@ -235,20 +235,20 @@ fn main() -> Result<()> {
                     host_centrality_path,
                     output_path,
                 } => entrypoint::Centrality::build_derived_harmonic(
-                    webgraph_path,
-                    host_centrality_path,
-                    output_path,
+                    &webgraph_path,
+                    &host_centrality_path,
+                    &output_path,
                 )?,
             }
             tracing::info!("Done");
         }
         Commands::Webgraph { options } => match options {
             WebgraphOptions::Create { config_path } => {
-                let config = load_toml_config(config_path);
+                let config = load_toml_config(&config_path);
                 entrypoint::Webgraph::run(&config)?;
             }
             WebgraphOptions::Merge { mut paths } => {
-                let mut webgraph = WebgraphBuilder::new(paths.remove(0)).open();
+                let mut webgraph = WebgraphBuilder::new(&paths.remove(0)).open();
 
                 for other_path in paths {
                     let other = WebgraphBuilder::new(&other_path).open();
@@ -257,7 +257,7 @@ fn main() -> Result<()> {
                 }
             }
             WebgraphOptions::Server { config_path } => {
-                let config: config::WebgraphServerConfig = load_toml_config(config_path);
+                let config: config::WebgraphServerConfig = load_toml_config(&config_path);
 
                 tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
@@ -266,7 +266,7 @@ fn main() -> Result<()> {
             }
         },
         Commands::Api { config_path } => {
-            let config: config::ApiConfig = load_toml_config(config_path);
+            let config: config::ApiConfig = load_toml_config(&config_path);
 
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -274,7 +274,7 @@ fn main() -> Result<()> {
                 .block_on(api::run(config))?
         }
         Commands::SearchServer { config_path } => {
-            let config: config::SearchServerConfig = load_toml_config(config_path);
+            let config: config::SearchServerConfig = load_toml_config(&config_path);
 
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -287,7 +287,7 @@ fn main() -> Result<()> {
             ms_sleep_between_req,
             output_dir,
         } => {
-            autosuggest_scrape::run(queries_to_scrape, gl, ms_sleep_between_req, output_dir)?;
+            autosuggest_scrape::run(queries_to_scrape, gl, ms_sleep_between_req, &output_dir)?;
         }
         #[cfg(feature = "dev")]
         Commands::Configure {
@@ -303,10 +303,10 @@ fn main() -> Result<()> {
         Commands::DmozParser {
             dmoz_file,
             output_path,
-        } => entrypoint::dmoz_parser::run(dmoz_file, output_path).unwrap(),
+        } => entrypoint::dmoz_parser::run(&dmoz_file, &output_path).unwrap(),
         Commands::Crawler { options } => match options {
             Crawler::Worker { config_path } => {
-                let config: config::CrawlerConfig = load_toml_config(config_path);
+                let config: config::CrawlerConfig = load_toml_config(&config_path);
 
                 tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
@@ -314,7 +314,7 @@ fn main() -> Result<()> {
                     .block_on(entrypoint::crawler::worker(config))?
             }
             Crawler::Coordinator { config_path } => {
-                let config: config::CrawlCoordinatorConfig = load_toml_config(config_path);
+                let config: config::CrawlCoordinatorConfig = load_toml_config(&config_path);
 
                 tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
@@ -322,7 +322,7 @@ fn main() -> Result<()> {
                     .block_on(entrypoint::crawler::coordinator(config))?
             }
             Crawler::Router { config_path } => {
-                let config: config::CrawlRouterConfig = load_toml_config(config_path);
+                let config: config::CrawlRouterConfig = load_toml_config(&config_path);
 
                 tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
@@ -330,7 +330,7 @@ fn main() -> Result<()> {
                     .block_on(entrypoint::crawler::router(config))?
             }
             Crawler::Plan { config_path } => {
-                let config: config::CrawlPlannerConfig = load_toml_config(config_path);
+                let config: config::CrawlPlannerConfig = load_toml_config(&config_path);
 
                 entrypoint::crawler::planner(config)?;
             }
@@ -339,9 +339,9 @@ fn main() -> Result<()> {
             SafetyClassifierOptions::Train {
                 dataset_path,
                 output_path,
-            } => safety_classifier::train(dataset_path, output_path)?,
+            } => safety_classifier::train(&dataset_path, &output_path)?,
             SafetyClassifierOptions::Predict { model_path, text } => {
-                safety_classifier::predict(model_path, &text)?
+                safety_classifier::predict(&model_path, &text)?
             }
         },
     }

--- a/core/src/qa_model.rs
+++ b/core/src/qa_model.rs
@@ -47,7 +47,7 @@ pub struct Answer {
 }
 
 impl QaModel {
-    pub fn open<P: AsRef<Path>>(folder: P) -> Result<Self> {
+    pub fn open(folder: &Path) -> Result<Self> {
         let truncation = TruncationParams {
             max_length: TRUNCATE_INPUT,
             ..Default::default()
@@ -56,12 +56,11 @@ impl QaModel {
             ..Default::default()
         };
 
-        let mut tokenizer =
-            tokenizers::Tokenizer::from_file(folder.as_ref().join("tokenizer.json"))?;
+        let mut tokenizer = tokenizers::Tokenizer::from_file(folder.join("tokenizer.json"))?;
         tokenizer.with_truncation(Some(truncation))?;
         tokenizer.with_padding(Some(padding));
 
-        let model = tch::CModule::load(folder.as_ref().join("model.pt"))?;
+        let model = tch::CModule::load(folder.join("model.pt"))?;
         Ok(Self {
             tokenizer,
             model,
@@ -199,7 +198,7 @@ mod tests {
 
     fn open_qa_model() -> QaModel {
         QaModel::open(
-            std::path::Path::new("../data/qa_model")
+            &std::path::Path::new("../data/qa_model")
                 .canonicalize()
                 .expect("QA model not found in data/qa_model"),
         )

--- a/core/src/query/optic.rs
+++ b/core/src/query/optic.rs
@@ -623,7 +623,7 @@ mod tests {
         let mut index = Index::temporary().expect("Unable to open index");
 
         let mut writer = WebgraphWriter::new(
-            gen_temp_path(),
+            &gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
         );

--- a/core/src/ranking/inbound_similarity.rs
+++ b/core/src/ranking/inbound_similarity.rs
@@ -179,7 +179,7 @@ impl InboundSimilarity {
         }
     }
 
-    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+    pub fn save(&self, path: &Path) -> Result<()> {
         let mut file = BufWriter::new(
             File::options()
                 .create(true)
@@ -197,7 +197,7 @@ impl InboundSimilarity {
         self.vectors.get(node)
     }
 
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub fn open(path: &Path) -> Result<Self> {
         let file = File::open(path)?;
         let mut reader = BufReader::new(file);
 
@@ -230,7 +230,7 @@ mod tests {
     #[test]
     fn it_favors_liked_sites() {
         let mut wrt = WebgraphWriter::new(
-            gen_temp_path(),
+            &gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
         );
@@ -259,7 +259,7 @@ mod tests {
     #[test]
     fn it_ranks_search_results() {
         let mut wrt = WebgraphWriter::new(
-            crate::gen_temp_path(),
+            &crate::gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
         );

--- a/core/src/ranking/models/cross_encoder.rs
+++ b/core/src/ranking/models/cross_encoder.rs
@@ -38,7 +38,7 @@ mod model {
     }
 
     impl CrossEncoderModel {
-        pub fn open<P: AsRef<Path>>(folder: P) -> Result<Self> {
+        pub fn open(folder: &Path) -> Result<Self> {
             let truncation = TruncationParams {
                 max_length: TRUNCATE_INPUT,
                 ..Default::default()
@@ -48,16 +48,15 @@ mod model {
                 ..Default::default()
             };
 
-            let mut tokenizer =
-                tokenizers::Tokenizer::from_file(folder.as_ref().join("tokenizer.json"))
-                    .map_err(|_| anyhow!("couldn't open tokenizer"))?;
+            let mut tokenizer = tokenizers::Tokenizer::from_file(folder.join("tokenizer.json"))
+                .map_err(|_| anyhow!("couldn't open tokenizer"))?;
 
             tokenizer
                 .with_truncation(Some(truncation))
                 .map_err(|_| anyhow!("tokenizer truncation settings"))?;
             tokenizer.with_padding(Some(padding));
 
-            let model = tch::CModule::load(folder.as_ref().join("model.pt"))?;
+            let model = tch::CModule::load(folder.join("model.pt"))?;
 
             Ok(Self { tokenizer, model })
         }
@@ -159,7 +158,7 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-        let model = CrossEncoderModel::open("../data/cross_encoder")
+        let model = CrossEncoderModel::open("../data/cross_encoder".as_ref())
             .expect("Failed to find cross-encoder model");
 
         let s = model.run(

--- a/core/src/ranking/models/lambdamart.rs
+++ b/core/src/ranking/models/lambdamart.rs
@@ -259,7 +259,7 @@ pub struct LambdaMART {
 }
 
 impl LambdaMART {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub fn open(path: &Path) -> Result<Self> {
         let s = std::fs::read_to_string(path)?;
         let tree = Tree::parse(&s)?;
         Ok(Self { tree })

--- a/core/src/ranking/models/linear.rs
+++ b/core/src/ranking/models/linear.rs
@@ -45,7 +45,7 @@ pub struct LinearRegression {
 }
 
 impl LinearRegression {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub fn open(path: &Path) -> Result<Self> {
         let file = File::open(path)?;
         let reader = BufReader::new(file);
         let model: SerialziedLinearRegression = serde_json::from_reader(reader)?;

--- a/core/src/ranking/optics.rs
+++ b/core/src/ranking/optics.rs
@@ -33,7 +33,7 @@ mod tests {
         let mut index = Index::temporary().expect("Unable to open index");
 
         let mut wrt = WebgraphWriter::new(
-            gen_temp_path(),
+            &gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
         );

--- a/core/src/searcher/local.rs
+++ b/core/src/searcher/local.rs
@@ -321,7 +321,7 @@ impl LocalSearcher {
         #[cfg(feature = "libtorch")]
         let pipeline = {
             use crate::ranking::models::cross_encoder::CrossEncoderModel;
-            match CrossEncoderModel::open("data/cross_encoder") {
+            match CrossEncoderModel::open("data/cross_encoder".as_ref()) {
                 Ok(model) => RankingPipeline::reranking_for_query::<CrossEncoderModel>(
                     &mut search_query,
                     Some(Arc::new(model)),

--- a/core/src/spell/word2vec.rs
+++ b/core/src/spell/word2vec.rs
@@ -138,7 +138,7 @@ pub struct Word2Vec {
 }
 
 impl Word2Vec {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+    pub fn open(path: &Path) -> Result<Self, Error> {
         let reader = BufReader::new(MultiGzDecoder::new(BufReader::new(File::open(path)?)));
         let reader = WordVectorReader::new_from_reader(reader)?;
         let vectors: HashMap<_, _> = reader.map(|(word, vec)| (word, WordVec(vec))).collect();

--- a/core/src/subdomain_count.rs
+++ b/core/src/subdomain_count.rs
@@ -27,7 +27,7 @@ pub struct SubdomainCounter {
 }
 
 impl SubdomainCounter {
-    pub fn open<P: AsRef<Path>>(path: P) -> Self {
+    pub fn open(path: &Path) -> Self {
         Self {
             inner: Box::new(RocksDbStore::open(path)),
         }

--- a/core/src/warc.rs
+++ b/core/src/warc.rs
@@ -68,7 +68,7 @@ impl WarcFile {
         Self { bytes }
     }
 
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub fn open(path: &Path) -> Result<Self> {
         let file = File::open(path)?;
         let mut reader = BufReader::new(file);
 

--- a/core/src/webgraph/centrality/betweenness.rs
+++ b/core/src/webgraph/centrality/betweenness.rs
@@ -170,7 +170,7 @@ mod tests {
 
     fn create_path_graph(n: usize) -> Webgraph {
         let mut writer = WebgraphWriter::new(
-            crate::gen_temp_path(),
+            &crate::gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
         );

--- a/core/src/webgraph/centrality/derived_harmonic.rs
+++ b/core/src/webgraph/centrality/derived_harmonic.rs
@@ -67,17 +67,17 @@ pub struct DerivedCentrality {
 }
 
 impl DerivedCentrality {
-    pub fn open<P: AsRef<Path>>(path: P) -> Self {
+    pub fn open(path: &Path) -> Self {
         let inner = RocksDbStore::open(path);
         Self { inner }
     }
 
-    pub fn build<P: AsRef<Path>>(
+    pub fn build(
         host_harmonic: &RocksDbStore<NodeID, f64>,
         page_graph: &Webgraph,
-        output: P,
+        output: &Path,
     ) -> Result<Self> {
-        if output.as_ref().exists() {
+        if output.exists() {
             return Err(anyhow::anyhow!("output path already exists"));
         }
 
@@ -91,7 +91,7 @@ impl DerivedCentrality {
 
         let has_outgoing = has_outgoing.finalize();
 
-        let non_normalized = RocksDbStore::open(output.as_ref().join("non_normalized"));
+        let non_normalized = RocksDbStore::open(&output.join("non_normalized"));
 
         let norms: Mutex<BTreeMap<NodeID, f64>> = Mutex::new(BTreeMap::new());
 
@@ -126,7 +126,7 @@ impl DerivedCentrality {
 
         let norms = norms.into_inner().unwrap();
 
-        let db = RocksDbStore::open(output.as_ref());
+        let db = RocksDbStore::open(output);
         for (id, score) in non_normalized.iter() {
             let node = page_graph.id2node(&id).unwrap().into_host().id();
             let norm = norms.get(&node).unwrap();
@@ -136,7 +136,7 @@ impl DerivedCentrality {
         db.flush();
 
         drop(non_normalized);
-        std::fs::remove_dir_all(output.as_ref().join("non_normalized"))?;
+        std::fs::remove_dir_all(output.join("non_normalized"))?;
 
         Ok(Self { inner: db })
     }

--- a/core/src/webgraph/centrality/harmonic.rs
+++ b/core/src/webgraph/centrality/harmonic.rs
@@ -216,7 +216,7 @@ mod tests {
 
     fn test_graph() -> Webgraph {
         let mut writer = WebgraphWriter::new(
-            crate::gen_temp_path(),
+            &crate::gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
         );
@@ -231,7 +231,7 @@ mod tests {
     #[test]
     fn host_harmonic_centrality() {
         let mut writer = WebgraphWriter::new(
-            crate::gen_temp_path(),
+            &crate::gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
         );
@@ -339,7 +339,7 @@ mod tests {
         let centrality = HarmonicCentrality::calculate(&graph);
 
         let mut other = WebgraphWriter::new(
-            crate::gen_temp_path(),
+            &crate::gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
         );

--- a/core/src/webgraph/mod.rs
+++ b/core/src/webgraph/mod.rs
@@ -309,9 +309,9 @@ pub struct WebgraphBuilder {
 }
 
 impl WebgraphBuilder {
-    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+    pub fn new(path: &Path) -> Self {
         Self {
-            path: path.as_ref().into(),
+            path: path.into(),
             executor: Executor::multi_thread("webgraph").unwrap(),
             compression: Compression::default(),
         }
@@ -328,7 +328,7 @@ impl WebgraphBuilder {
     }
 
     pub fn open(self) -> Webgraph {
-        Webgraph::open(self.path, self.executor, self.compression)
+        Webgraph::open(&self.path, self.executor, self.compression)
     }
 }
 
@@ -416,7 +416,7 @@ struct Meta {
 }
 
 impl Meta {
-    fn open<P: AsRef<Path>>(path: P) -> Self {
+    fn open(path: &Path) -> Self {
         let mut reader = BufReader::new(
             File::options()
                 .create(true)
@@ -430,7 +430,7 @@ impl Meta {
         serde_json::from_str(&buf).unwrap_or_default()
     }
 
-    fn save<P: AsRef<Path>>(&self, path: P) {
+    fn save(&self, path: &Path) {
         let mut writer = BufWriter::new(
             File::options()
                 .create(true)
@@ -451,7 +451,7 @@ struct Id2NodeDb {
 }
 
 impl Id2NodeDb {
-    fn open<P: AsRef<Path>>(path: P) -> Self {
+    fn open(path: &Path) -> Self {
         let mut opts = rocksdb::Options::default();
         opts.create_if_missing(true);
         opts.optimize_for_point_lookup(512);
@@ -537,32 +537,32 @@ pub struct WebgraphWriter {
 }
 
 impl WebgraphWriter {
-    fn meta<P: AsRef<Path>>(path: P) -> Meta {
-        let meta_path = path.as_ref().join("metadata.json");
-        Meta::open(meta_path)
+    fn meta(path: &Path) -> Meta {
+        let meta_path = path.join("metadata.json");
+        Meta::open(&meta_path)
     }
 
     fn save_metadata(&mut self) {
         let path = Path::new(&self.path).join("metadata.json");
-        self.meta.save(path);
+        self.meta.save(&path);
     }
 
-    pub fn new<P: AsRef<Path>>(path: P, executor: Executor, compression: Compression) -> Self {
-        fs::create_dir_all(&path).unwrap();
-        let mut meta = Self::meta(&path);
+    pub fn new(path: &Path, executor: Executor, compression: Compression) -> Self {
+        fs::create_dir_all(path).unwrap();
+        let mut meta = Self::meta(path);
         meta.comitted_segments.clear();
 
-        fs::create_dir_all(path.as_ref().join("segments")).unwrap();
+        fs::create_dir_all(path.join("segments")).unwrap();
 
         let id = uuid::Uuid::new_v4().to_string();
-        let segment = SegmentWriter::open(path.as_ref().join("segments"), id.clone(), compression);
+        let segment = SegmentWriter::open(&path.join("segments"), id.clone(), compression);
 
         meta.comitted_segments.push(id);
 
         Self {
-            path: path.as_ref().as_os_str().to_str().unwrap().to_string(),
+            path: path.as_os_str().to_str().unwrap().to_string(),
             segment,
-            id2node: Id2NodeDb::open(path.as_ref().join("id2node")),
+            id2node: Id2NodeDb::open(&path.join("id2node")),
             insert_batch: Vec::with_capacity(store::MAX_BATCH_SIZE),
             executor,
             meta,
@@ -638,36 +638,36 @@ pub struct Webgraph {
 }
 
 impl Webgraph {
-    fn meta<P: AsRef<Path>>(path: P) -> Meta {
-        let meta_path = path.as_ref().join("metadata.json");
-        Meta::open(meta_path)
+    fn meta(path: &Path) -> Meta {
+        let meta_path = path.join("metadata.json");
+        Meta::open(&meta_path)
     }
 
     fn save_metadata(&mut self) {
         let path = Path::new(&self.path).join("metadata.json");
-        self.meta.save(path);
+        self.meta.save(&path);
     }
 
-    fn open<P: AsRef<Path>>(path: P, executor: Executor, compression: Compression) -> Self {
-        fs::create_dir_all(&path).unwrap();
-        let meta = Self::meta(&path);
+    fn open(path: &Path, executor: Executor, compression: Compression) -> Self {
+        fs::create_dir_all(path).unwrap();
+        let meta = Self::meta(path);
 
-        fs::create_dir_all(path.as_ref().join("segments")).unwrap();
+        fs::create_dir_all(path.join("segments")).unwrap();
 
         let mut segments = Vec::new();
         for segment in &meta.comitted_segments {
             segments.push(Segment::open(
-                path.as_ref().join("segments"),
+                &path.join("segments"),
                 segment.clone(),
                 compression,
             ));
         }
 
         Self {
-            path: path.as_ref().as_os_str().to_str().unwrap().to_string(),
+            path: path.as_os_str().to_str().unwrap().to_string(),
             segments,
             executor: Arc::new(executor),
-            id2node: Id2NodeDb::open(path.as_ref().join("id2node")),
+            id2node: Id2NodeDb::open(&path.join("id2node")),
             meta,
             compression,
         }
@@ -684,7 +684,7 @@ impl Webgraph {
             self.meta.comitted_segments.push(segment.id());
             drop(segment);
             self.segments
-                .push(Segment::open(new_path, id, self.compression));
+                .push(Segment::open(&new_path, id, self.compression));
         }
 
         self.save_metadata();
@@ -837,7 +837,7 @@ mod test {
         //        D
 
         let mut graph = WebgraphWriter::new(
-            crate::gen_temp_path(),
+            &crate::gen_temp_path(),
             Executor::single_thread(),
             Compression::default(),
         );
@@ -899,7 +899,7 @@ mod test {
             (Node::from("G"), Node::from("H"), String::new()),
         ] {
             let mut wrt = WebgraphWriter::new(
-                crate::gen_temp_path(),
+                &crate::gen_temp_path(),
                 Executor::single_thread(),
                 Compression::default(),
             );
@@ -928,7 +928,7 @@ mod test {
             (Node::from("C"), Node::from("A"), String::new()),
         ] {
             let mut wrt = WebgraphWriter::new(
-                crate::gen_temp_path(),
+                &crate::gen_temp_path(),
                 Executor::single_thread(),
                 Compression::default(),
             );
@@ -970,7 +970,7 @@ mod test {
     #[test]
     fn cap_label_length() {
         let mut writer = WebgraphWriter::new(
-            crate::gen_temp_path(),
+            &crate::gen_temp_path(),
             Executor::single_thread(),
             Compression::default(),
         );
@@ -993,7 +993,7 @@ mod test {
     #[test]
     fn edges_by_host() {
         let mut writer = WebgraphWriter::new(
-            crate::gen_temp_path(),
+            &crate::gen_temp_path(),
             Executor::single_thread(),
             Compression::default(),
         );

--- a/core/src/webgraph/segment.rs
+++ b/core/src/webgraph/segment.rs
@@ -32,27 +32,19 @@ pub struct SegmentWriter {
 }
 
 impl SegmentWriter {
-    pub fn open<P: AsRef<Path>>(folder_path: P, id: String, compression: Compression) -> Self {
+    pub fn open(folder_path: &Path, id: String, compression: Compression) -> Self {
         SegmentWriter {
             full_adjacency: EdgeStoreWriter::open(
-                folder_path.as_ref().join(&id).join(ADJACENCY_STORE),
+                &folder_path.join(&id).join(ADJACENCY_STORE),
                 compression,
                 false,
             ),
             full_reversed_adjacency: EdgeStoreWriter::open(
-                folder_path
-                    .as_ref()
-                    .join(&id)
-                    .join(REVERSED_ADJACENCY_STORE),
+                &folder_path.join(&id).join(REVERSED_ADJACENCY_STORE),
                 compression,
                 true,
             ),
-            folder_path: folder_path
-                .as_ref()
-                .as_os_str()
-                .to_str()
-                .unwrap()
-                .to_string(),
+            folder_path: folder_path.as_os_str().to_str().unwrap().to_string(),
             id,
         }
     }
@@ -87,27 +79,19 @@ pub struct Segment {
 }
 
 impl Segment {
-    pub fn open<P: AsRef<Path>>(folder_path: P, id: String, compression: Compression) -> Self {
+    pub fn open(folder_path: &Path, id: String, compression: Compression) -> Self {
         Segment {
             full_adjacency: EdgeStore::open(
-                folder_path.as_ref().join(&id).join(ADJACENCY_STORE),
+                &folder_path.join(&id).join(ADJACENCY_STORE),
                 false,
                 compression,
             ),
             full_reversed_adjacency: EdgeStore::open(
-                folder_path
-                    .as_ref()
-                    .join(&id)
-                    .join(REVERSED_ADJACENCY_STORE),
+                &folder_path.join(&id).join(REVERSED_ADJACENCY_STORE),
                 true,
                 compression,
             ),
-            folder_path: folder_path
-                .as_ref()
-                .as_os_str()
-                .to_str()
-                .unwrap()
-                .to_string(),
+            folder_path: folder_path.as_os_str().to_str().unwrap().to_string(),
             id,
         }
     }
@@ -165,7 +149,7 @@ mod test {
         // 1─────►2◄┘
 
         let mut writer = SegmentWriter::open(
-            crate::gen_temp_path(),
+            &crate::gen_temp_path(),
             "test".to_string(),
             Compression::default(),
         );

--- a/core/src/webgraph/store.rs
+++ b/core/src/webgraph/store.rs
@@ -38,7 +38,7 @@ pub struct EdgeStoreWriter {
 }
 
 impl EdgeStoreWriter {
-    pub fn open<P: AsRef<Path>>(path: P, compression: Compression, reversed: bool) -> Self {
+    pub fn open(path: &Path, compression: Compression, reversed: bool) -> Self {
         let mut options = rocksdb::Options::default();
         options.create_if_missing(true);
 
@@ -69,7 +69,7 @@ impl EdgeStoreWriter {
         options.set_block_based_table_factory(&block_options);
         options.set_compression_type(rocksdb::DBCompressionType::Lz4);
 
-        let db = rocksdb::DB::open(&options, path.as_ref().join("writer")).unwrap();
+        let db = rocksdb::DB::open(&options, path.join("writer")).unwrap();
 
         Self {
             db,
@@ -163,7 +163,7 @@ struct PrefixDb {
 }
 
 impl PrefixDb {
-    fn open<P: AsRef<Path>>(path: P) -> Self {
+    fn open(path: &Path) -> Self {
         let mut options = rocksdb::Options::default();
         options.create_if_missing(true);
 
@@ -261,7 +261,7 @@ pub struct EdgeStore {
 }
 
 impl EdgeStore {
-    pub fn open<P: AsRef<Path>>(path: P, reversed: bool, compression: Compression) -> Self {
+    pub fn open(path: &Path, reversed: bool, compression: Compression) -> Self {
         let mut options = rocksdb::Options::default();
         options.create_if_missing(true);
 
@@ -295,12 +295,12 @@ impl EdgeStore {
 
         let ranges = match rocksdb::DB::open_cf_with_opts(
             &options,
-            path.as_ref().join("ranges"),
+            path.join("ranges"),
             [("nodes", options.clone()), ("labels", options.clone())],
         ) {
             Ok(db) => db,
             Err(_) => {
-                let mut ranges = rocksdb::DB::open(&options, path.as_ref().join("ranges")).unwrap();
+                let mut ranges = rocksdb::DB::open(&options, path.join("ranges")).unwrap();
 
                 ranges.create_cf("nodes", &options).unwrap();
                 ranges.create_cf("labels", &options).unwrap();
@@ -313,7 +313,7 @@ impl EdgeStore {
             .read(true)
             .create(true)
             .write(true)
-            .open(path.as_ref().join("labels"))
+            .open(path.join("labels"))
             .unwrap();
         let edge_labels = unsafe { Mmap::map(&edge_labels_file).unwrap() };
         let edge_labels_len = edge_labels.len();
@@ -322,7 +322,7 @@ impl EdgeStore {
             .read(true)
             .create(true)
             .write(true)
-            .open(path.as_ref().join("nodes"))
+            .open(path.join("nodes"))
             .unwrap();
         let edge_nodes = unsafe { Mmap::map(&edge_nodes_file).unwrap() };
         let edge_nodes_len = edge_nodes.len();
@@ -330,7 +330,7 @@ impl EdgeStore {
         Self {
             reversed,
             ranges,
-            prefixes: PrefixDb::open(path.as_ref().join("prefixes")),
+            prefixes: PrefixDb::open(&path.join("prefixes")),
             _cache: cache,
             edge_labels,
             edge_labels_len,
@@ -417,8 +417,8 @@ impl EdgeStore {
 
     /// Build a new edge store from a set of edges. The edges must be sorted by
     /// either the from or to node, depending on the value of `reversed`.
-    fn build<P: AsRef<Path>>(
-        path: P,
+    fn build(
+        path: &Path,
         compression: Compression,
         reversed: bool,
         edges: impl Iterator<Item = InnerEdge<String>>,
@@ -601,7 +601,7 @@ mod tests {
     #[test]
     fn test_insert() {
         let kv: EdgeStoreWriter = EdgeStoreWriter::open(
-            crate::gen_temp_path().join("test-segment"),
+            &crate::gen_temp_path().join("test-segment"),
             Compression::default(),
             false,
         );
@@ -635,7 +635,7 @@ mod tests {
     #[test]
     fn test_reversed() {
         let kv: EdgeStoreWriter = EdgeStoreWriter::open(
-            crate::gen_temp_path().join("test-segment"),
+            &crate::gen_temp_path().join("test-segment"),
             Compression::default(),
             true,
         );

--- a/core/src/webpage/region.rs
+++ b/core/src/webpage/region.rs
@@ -132,16 +132,16 @@ pub struct RegionCount {
 }
 
 impl RegionCount {
-    pub fn open<P: AsRef<Path>>(path: P) -> Self {
-        let map: HashMap<Region, u64> = if !path.as_ref().exists() {
-            if let Some(parent) = path.as_ref().parent() {
+    pub fn open(path: &Path) -> Self {
+        let map: HashMap<Region, u64> = if !path.exists() {
+            if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent).unwrap();
             }
-            File::create(path.as_ref()).unwrap();
+            File::create(path).unwrap();
 
             HashMap::new()
         } else {
-            let json = std::fs::read_to_string(path.as_ref()).unwrap_or_default();
+            let json = std::fs::read_to_string(path).unwrap_or_default();
             serde_json::from_str(&json).unwrap_or_else(|_| HashMap::new())
         };
 
@@ -161,7 +161,7 @@ impl RegionCount {
             total_counts: map.values().sum(),
             map,
             fast_count,
-            path: path.as_ref().to_str().unwrap().to_string(),
+            path: path.to_str().unwrap().to_string(),
         }
     }
 
@@ -221,13 +221,13 @@ mod tests {
 
     #[test]
     fn simple() {
-        let mut a = RegionCount::open(gen_temp_path().join("region_count.json"));
+        let mut a = RegionCount::open(&gen_temp_path().join("region_count.json"));
 
         a.increment(&Region::Denmark);
         a.increment(&Region::Denmark);
         a.increment(&Region::US);
 
-        let mut b = RegionCount::open(gen_temp_path().join("region_count.json"));
+        let mut b = RegionCount::open(&gen_temp_path().join("region_count.json"));
 
         b.increment(&Region::US);
         b.increment(&Region::Germany);

--- a/core/src/webpage/safety_classifier.rs
+++ b/core/src/webpage/safety_classifier.rs
@@ -61,7 +61,7 @@ pub struct Datapoint {
     pub text: String,
 }
 
-pub fn load_dataset<P: AsRef<Path>>(path: P) -> Result<Vec<Datapoint>> {
+pub fn load_dataset(path: &Path) -> Result<Vec<Datapoint>> {
     let mut datapoints = Vec::new();
     let mut reader = csv::Reader::from_path(path)?;
     for result in reader.deserialize() {
@@ -166,7 +166,7 @@ impl Model {
         }
     }
 
-    pub fn save<P: AsRef<Path>>(self, path: P) -> Result<()> {
+    pub fn save(self, path: &Path) -> Result<()> {
         let file = OpenOptions::new()
             .write(true)
             .create(true)
@@ -178,7 +178,7 @@ impl Model {
         Ok(())
     }
 
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub fn open(path: &Path) -> Result<Self> {
         let file = OpenOptions::new().read(true).open(path)?;
 
         let model = bincode::deserialize_from(file)?;

--- a/core/src/widgets/mod.rs
+++ b/core/src/widgets/mod.rs
@@ -45,7 +45,7 @@ impl Widgets {
         }
 
         let thesaurus = if let Some(path) = config.thesaurus_paths.first() {
-            Some(thesaurus::Dictionary::build(path)?)
+            Some(thesaurus::Dictionary::build(path.as_ref())?)
         } else {
             None
         };

--- a/core/src/widgets/thesaurus.rs
+++ b/core/src/widgets/thesaurus.rs
@@ -276,7 +276,7 @@ impl Dictionary {
         self.spellings.insert(normalized, lemma);
     }
 
-    pub fn build<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub fn build(path: &Path) -> Result<Self> {
         let reader = BufReader::new(File::open(path)?);
 
         let mut parser = TurtleParser::new(reader, None);
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn build_dict() {
-        let dict = Dictionary::build("../data/english-wordnet-2022-subset.ttl").unwrap();
+        let dict = Dictionary::build("../data/english-wordnet-2022-subset.ttl".as_ref()).unwrap();
 
         let infos = dict.get(Lemma("barely".to_string()));
 


### PR DESCRIPTION
This reduces LLVM lines from 1335068 to 1227782, which is a 8% decrease!

Unfortunetly it does not (yet) yield any compile-time benefits. These are the results of incremental `cargo build`:

| Branch | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `main` | 8.119 ± 0.066 | 8.012 | 8.264 | 1.00 ± 0.01 |
| `purge` | 8.084 ± 0.054 | 8.016 | 8.182 | 1.00 |

<details>
<summary><i>Benchmarks are run using the following command:</i></summary>

```bash
hyperfine --show-output -w 2 --export-markdown bench-compile-main-vs-purge.md \
    -p "git switch main              && touch core/src/lib.rs && sleep 1" -n "main"  "cargo build" \
    -p "git switch purge-as-ref-path && touch core/src/lib.rs && sleep 1" -n "purge" "cargo build"
```

</details>