### PR TITLE
Make `SmallPatternPart` pub

### DIFF
--- a/core/src/query/pattern_query/mod.rs
+++ b/core/src/query/pattern_query/mod.rs
@@ -167,7 +167,7 @@ impl tantivy::query::Query for PatternQuery {
 }
 
 #[derive(Debug)]
-enum SmallPatternPart {
+pub enum SmallPatternPart {
     Term,
     Wildcard,
     Anchor,


### PR DESCRIPTION
This is required because it was used as an argument to `NormalPatternScorer::new`. With it being private, compilation would fail.