### PR TITLE
Update axum to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
 dependencies = [
- "http",
+ "http 0.2.9",
  "log",
  "native-tls",
  "serde",
@@ -296,18 +296,19 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "202651474fe73c62d9e0a56c6133f7a0ff1dc1c8cf7a5b03381af2a26553ac9d"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-util",
  "itoa 1.0.9",
  "matchit",
  "memchr",
@@ -328,37 +329,40 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "77cb22c689c44d4c07b0ab44ebc25d69d8ae601a2f28fb8d672d344178fa17aa"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-extra"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab90e7b70bea63a153137162affb6a0bce26b584c24a4c7885509783e2cf30b"
+checksum = "523ae92256049a3b02d3bb4df80152386cd97ddba0c8c5077619bdc8c4b1859b"
 dependencies = [
  "axum",
  "axum-core",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "mime",
  "pin-project-lite",
  "serde",
- "tokio",
  "tower",
  "tower-layer",
  "tower-service",
@@ -366,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.3.8"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
+checksum = "5a2edad600410b905404c594e2523549f1bcd4bded1e252c8f74524ccce0b867"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -1628,8 +1632,27 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.9",
  "indexmap 1.9.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.0.0",
+ "indexmap 2.0.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -1748,21 +1771,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa 1.0.9",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.9",
  "pin-project-lite",
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
+name = "http-body"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "httparse"
@@ -1786,9 +1837,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.21",
+ "http 0.2.9",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa 1.0.9",
@@ -1801,16 +1852,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.0",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa 1.0.9",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.27",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca339002caeb0d159cc6e023dff48e199f081e42fa039895c7c6f38b37f2e9d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.1.0",
+ "pin-project-lite",
+ "socket2 0.5.4",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3534,10 +3624,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.21",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3699,7 +3789,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac",
- "http",
+ "http 0.2.9",
  "log",
  "maybe-async",
  "md5",
@@ -4239,7 +4329,7 @@ dependencies = [
  "futures",
  "half 2.3.1",
  "hashbrown 0.14.1",
- "http",
+ "http 1.0.0",
  "image",
  "indicatif 0.17.7",
  "insta",
@@ -4916,18 +5006,17 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "09e12e6351354851911bdf8c2b8f2ab15050c567d70a8b9a37ae7b8301a4080d"
 dependencies = [
  "async-compression",
  "bitflags 2.4.1",
  "bytes",
- "futures-core",
  "futures-util",
- "http",
- "http-body",
- "http-range-header",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -5179,9 +5268,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154517adf0d0b6e22e8e1f385628f14fcaa3db43531dc74303d3edef89d6dfe5"
+checksum = "f839caa8e09dddc3ff1c3112a91ef7da0601075ba5025d9f33ae99c4cb9b6e51"
 dependencies = [
  "axum",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ anyhow = {version = "1.0.72", features = ["backtrace"]}
 async-channel = "1.8.0"
 async-stream = "0.3.3"
 async-trait = "0.1.57"
-axum = "0.6.9"
-axum-extra = {version = "0.8.0"}
-axum-macros = "0.3.4"
+axum = "0.7.2"
+axum-extra = {version = "0.9.0"}
+axum-macros = "0.4.0"
 base64 = "0.21.4"
 bincode = "1.3.3"
 bitvec = "1.0.1"
@@ -40,7 +40,7 @@ fst = {version = "0.4.7", features = ["levenshtein"]}
 futures = "0.3.21"
 half = {version = "2.2.1", features = ["serde"]}
 hashbrown = {version = "0.14.0", features = ["serde", "rkyv"]}
-http = "0.2.8"
+http = "1.0.0"
 image = "0.24.3"
 indicatif = {version = "0.17.7", features = ["rayon"]}
 insta = "1.31"
@@ -98,13 +98,13 @@ tokenizers = "0.13.2"
 tokio = {version = "1.23.1", features = ["full"]}
 tokio-stream = "0.1.11"
 toml = "0.8.2"
-tower-http = {version = "0.4.0", features = ["compression-gzip", "cors"]}
+tower-http = {version = "0.5.0", features = ["compression-gzip", "cors"]}
 tracing = "0.1.34"
 tracing-subscriber = {version = "0.3.11", features = ["env-filter"]}
 url = {version = "2.4.0", features = ["serde"]}
 urlencoding = "2.1.2"
 utoipa = {version = "4.0.0", features = ["axum_extras"]}
-utoipa-swagger-ui = {version = "4.0.0", features = ["axum"]}
+utoipa-swagger-ui = {version = "5.0.0", features = ["axum"]}
 uuid = "1.1.2"
 whatlang = {version = "0.16.0", features = ["serde"]}
 

--- a/core/src/api/docs.rs
+++ b/core/src/api/docs.rs
@@ -107,8 +107,7 @@ Remember to always give proper attributions to the sources you use from the sear
     }
 }
 
-pub fn router<S: Clone + Send + Sync + 'static, B: axum::body::HttpBody + Send + Sync + 'static>(
-) -> impl Into<Router<S, B>> {
+pub fn router<S: Clone + Send + Sync + 'static>() -> impl Into<Router<S>> {
     SwaggerUi::new("/beta/api/docs")
         .url("/beta/api/docs/openapi.json", ApiDoc::openapi())
         .config(

--- a/core/src/api/mod.rs
+++ b/core/src/api/mod.rs
@@ -247,11 +247,11 @@ pub fn metrics_router(registry: crate::metrics::PrometheusRegistry) -> Router {
         .with_state(Arc::new(registry))
 }
 
-async fn search_metric<B>(
+async fn search_metric(
     extract::State(state): extract::State<Arc<State>>,
     extract::ConnectInfo(addr): extract::ConnectInfo<SocketAddr>,
-    request: axum::http::Request<B>,
-    next: middleware::Next<B>,
+    request: axum::extract::Request,
+    next: middleware::Next,
 ) -> Response {
     // It is very important that the ip address is not stored. It is only used
     // for a probabilistic estimate of the number of unique users using a hyperloglog datastructure.

--- a/core/src/entrypoint/alice.rs
+++ b/core/src/entrypoint/alice.rs
@@ -27,7 +27,7 @@ use axum::{
     Router,
 };
 use base64::Engine;
-use tokio::sync::Mutex;
+use tokio::{net::TcpListener, sync::Mutex};
 use tokio_stream::Stream;
 use tokio_stream::StreamExt as _;
 use tracing::info;
@@ -192,10 +192,12 @@ pub async fn run(config: AliceLocalConfig) -> Result<(), anyhow::Error> {
     let app = router(alice, cluster);
 
     info!("alice is ready to accept requests on {}", addr);
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    axum::serve(
+        TcpListener::bind(&addr).await.unwrap(),
+        app.into_make_service(),
+    )
+    .await
+    .unwrap();
 
     Ok(())
 }


### PR DESCRIPTION
This follows the recent release of axum 0.7: https://tokio.rs/blog/2023-11-27-announcing-axum-0-7-0

There are only a few small API changes, which generally just removes some generics.

Also, the API for serving endpoints has changed to use `axum::serve`. In these calls I think the `.into_make_service()` call, which was previously needed, can now be removed, but I'm not quite sure if it has some semantic difference (for example, some use `into_make_service_with_connect_info`, and we probably want to keep that).

Along with updating axum, we also updated `tower-http` and a few other related crates.