### PR TITLE
Open indexes that doesn't contain all the necesarry fields

### DIFF
--- a/core/src/fastfield_reader.rs
+++ b/core/src/fastfield_reader.rs
@@ -20,7 +20,7 @@ use tantivy::{columnar::ColumnValues, DocId, SegmentId};
 
 use crate::{
     enum_map::EnumMap,
-    schema::{DataType, FastField, ALL_FIELDS},
+    schema::{DataType, FastField, FieldMapping},
 };
 
 #[derive(Default, Clone)]
@@ -48,7 +48,7 @@ impl FastFieldReader {
 
             let mut field_readers = Vec::new();
 
-            for field in ALL_FIELDS.iter().filter_map(|field| field.as_fast()) {
+            for field in FieldMapping::all().filter_map(|field| field.as_fast()) {
                 let field_reader = match field.data_type() {
                     DataType::U64 => {
                         let reader = fastfield_readers.u64(field.name()).unwrap();

--- a/core/src/inverted_index.rs
+++ b/core/src/inverted_index.rs
@@ -43,7 +43,7 @@ use crate::query::Query;
 use crate::ranking::initial::Score;
 use crate::ranking::pipeline::RankingWebsite;
 use crate::ranking::SignalAggregator;
-use crate::schema::{FastField, Field, TextField, ALL_FIELDS};
+use crate::schema::{FastField, Field, FieldMapping, TextField};
 use crate::search_ctx::Ctx;
 use crate::snippet::TextSnippet;
 use crate::tokenizer::{
@@ -605,8 +605,8 @@ impl From<TantivyDocument> for RetrievedWebpage {
         let mut webpage = RetrievedWebpage::default();
 
         for value in doc.field_values() {
-            match ALL_FIELDS[value.field.field_id() as usize] {
-                Field::Text(TextField::Title) => {
+            match FieldMapping::get(value.field.field_id() as usize).copied() {
+                Some(Field::Text(TextField::Title)) => {
                     webpage.title = value
                         .value()
                         .as_value()
@@ -614,7 +614,7 @@ impl From<TantivyDocument> for RetrievedWebpage {
                         .expect("Title field should be text")
                         .to_string();
                 }
-                Field::Text(TextField::StemmedCleanBody) => {
+                Some(Field::Text(TextField::StemmedCleanBody)) => {
                     webpage.body = value
                         .value()
                         .as_value()
@@ -622,7 +622,7 @@ impl From<TantivyDocument> for RetrievedWebpage {
                         .expect("Body field should be text")
                         .to_string();
                 }
-                Field::Text(TextField::Description) => {
+                Some(Field::Text(TextField::Description)) => {
                     let desc = value
                         .value()
                         .as_value()
@@ -632,7 +632,7 @@ impl From<TantivyDocument> for RetrievedWebpage {
 
                     webpage.description = if desc.is_empty() { None } else { Some(desc) }
                 }
-                Field::Text(TextField::Url) => {
+                Some(Field::Text(TextField::Url)) => {
                     webpage.url = value
                         .value()
                         .as_value()
@@ -640,7 +640,7 @@ impl From<TantivyDocument> for RetrievedWebpage {
                         .expect("Url field should be text")
                         .to_string();
                 }
-                Field::Fast(FastField::LastUpdated) => {
+                Some(Field::Fast(FastField::LastUpdated)) => {
                     webpage.updated_time = {
                         let timestamp = value.value().as_value().as_u64().unwrap() as i64;
                         if timestamp == 0 {
@@ -650,7 +650,7 @@ impl From<TantivyDocument> for RetrievedWebpage {
                         }
                     }
                 }
-                Field::Text(TextField::AllBody) => {
+                Some(Field::Text(TextField::AllBody)) => {
                     webpage.dirty_body = value
                         .value()
                         .as_value()
@@ -658,13 +658,13 @@ impl From<TantivyDocument> for RetrievedWebpage {
                         .expect("All body field should be text")
                         .to_string();
                 }
-                Field::Fast(FastField::Region) => {
+                Some(Field::Fast(FastField::Region)) => {
                     webpage.region = {
                         let id = value.value().as_value().as_u64().unwrap();
                         Region::from_id(id)
                     }
                 }
-                Field::Text(TextField::DmozDescription) => {
+                Some(Field::Text(TextField::DmozDescription)) => {
                     let desc = value
                         .value()
                         .as_value()
@@ -674,7 +674,7 @@ impl From<TantivyDocument> for RetrievedWebpage {
 
                     webpage.dmoz_description = if desc.is_empty() { None } else { Some(desc) }
                 }
-                Field::Text(TextField::SchemaOrgJson) => {
+                Some(Field::Text(TextField::SchemaOrgJson)) => {
                     let json = value
                         .value()
                         .as_value()
@@ -684,15 +684,15 @@ impl From<TantivyDocument> for RetrievedWebpage {
 
                     webpage.schema_org = serde_json::from_str(&json).unwrap_or_default();
                 }
-                Field::Fast(FastField::LikelyHasAds) => {
+                Some(Field::Fast(FastField::LikelyHasAds)) => {
                     webpage.likely_has_ads =
                         value.value().as_value().as_u64().unwrap_or_default() != 0;
                 }
-                Field::Fast(FastField::LikelyHasPaywall) => {
+                Some(Field::Fast(FastField::LikelyHasPaywall)) => {
                     webpage.likely_has_paywall =
                         value.value().as_value().as_u64().unwrap_or_default() != 0;
                 }
-                Field::Text(TextField::RecipeFirstIngredientTagId) => {
+                Some(Field::Text(TextField::RecipeFirstIngredientTagId)) => {
                     let tag_id = value
                         .value()
                         .as_value()

--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -292,7 +292,7 @@ pub enum Field {
     Text(TextField),
 }
 
-pub static ALL_FIELDS: [Field; 65] = [
+static ALL_FIELDS: [Field; 65] = [
     Field::Text(TextField::Title),
     Field::Text(TextField::CleanBody),
     Field::Text(TextField::StemmedTitle),
@@ -360,6 +360,20 @@ pub static ALL_FIELDS: [Field; 65] = [
     Field::Fast(FastField::LikelyHasAds),
     Field::Fast(FastField::LikelyHasPaywall),
 ];
+
+pub struct FieldMapping;
+
+impl FieldMapping {
+    #[inline]
+    pub fn get(field_id: usize) -> Option<&'static Field> {
+        ALL_FIELDS.get(field_id)
+    }
+
+    #[inline]
+    pub fn all() -> impl Iterator<Item = &'static Field> {
+        ALL_FIELDS.iter()
+    }
+}
 
 impl Field {
     fn default_text_options(&self) -> tantivy::schema::TextOptions {

--- a/core/src/similar_hosts.rs
+++ b/core/src/similar_hosts.rs
@@ -156,6 +156,7 @@ impl SimilarHostsFinder {
         scored_nodes
             .into_iter()
             .filter(|ScoredNodeID { node_id, score: _ }| {
+                // remove dead links (nodes without outgoing edges might be dead links)
                 !self.webgraph.raw_outgoing_edges(node_id).is_empty()
             })
             .filter_map(|ScoredNodeID { node_id, score }| {

--- a/core/src/webpage/html/into_tantivy.rs
+++ b/core/src/webpage/html/into_tantivy.rs
@@ -17,7 +17,7 @@
 use crate::{
     ceil_char_boundary,
     prehashed::hash,
-    schema::{FastField, TextField},
+    schema::{FastField, FieldMapping, TextField},
     simhash, split_u128, tokenizer,
     webpage::url_ext::UrlExt,
     Error, Result,
@@ -30,7 +30,7 @@ use whatlang::Lang;
 
 use super::{find_recipe_first_ingredient_tag_id, schema_org, Html};
 
-use crate::schema::{Field, ALL_FIELDS, FLOAT_SCALING};
+use crate::schema::{Field, FLOAT_SCALING};
 
 impl Html {
     fn pretokenize_title(&self) -> Result<PreTokenizedString> {
@@ -197,7 +197,10 @@ impl Html {
         let domain_hash = split_u128(hash(self.url().root_domain().unwrap_or_default()).0);
         let title_hash = split_u128(hash(self.title().unwrap_or_default()).0);
 
-        for field in &ALL_FIELDS {
+        for field in schema
+            .fields()
+            .filter_map(|(field, _)| FieldMapping::get(field.field_id() as usize))
+        {
             let tantivy_field = schema
                 .get_field(field.name())
                 .unwrap_or_else(|_| panic!("Unknown field: {}", field.name()));

--- a/frontend/src/lib/components/Article.svelte
+++ b/frontend/src/lib/components/Article.svelte
@@ -1,5 +1,5 @@
 <article
-  class="prose prose-sm mx-auto py-20 leading-6 prose-headings:text-center prose-headings:font-medium prose-h4:float-left prose-h4:my-0 prose-h4:mr-3 prose-h4:leading-6"
+  class="px-5 prose prose-sm mx-auto py-20 leading-6 prose-headings:text-center prose-headings:font-medium prose-h4:float-left prose-h4:my-0 prose-h4:mr-3 prose-h4:leading-6"
 >
   <slot />
 </article>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
+    "outDir": "build",
     "allowJs": true,
     "checkJs": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This is useful to be able to update the code continously in production and not having to wait for next indexing. I just downloaded part of the production index to my local laptop, and I seem to be able to open the index without panics with these changes even though we have added multiple new fields since the index was built