### PR TITLE
Remove `#[async_trait]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4303,7 +4303,6 @@ dependencies = [
  "anyhow",
  "async-channel",
  "async-stream",
- "async-trait",
  "axum",
  "axum-extra",
  "axum-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ aes-gcm = "0.10.2"
 anyhow = {version = "1.0.72", features = ["backtrace"]}
 async-channel = "1.8.0"
 async-stream = "0.3.3"
-async-trait = "0.1.57"
 axum = "0.7.2"
 axum-extra = {version = "0.9.0"}
 axum-macros = "0.4.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,6 @@ aes-gcm = {workspace = true}
 anyhow = {workspace = true}
 async-channel = {workspace = true}
 async-stream = {workspace = true}
-async-trait = {workspace = true}
 axum = {workspace = true}
 axum-extra = {workspace = true}
 axum-macros = {workspace = true}

--- a/core/src/crawler/mod.rs
+++ b/core/src/crawler/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{collections::VecDeque, sync::Arc, time::Duration};
+use std::{collections::VecDeque, future::Future, sync::Arc, time::Duration};
 
 use hashbrown::HashMap;
 
@@ -264,8 +264,8 @@ impl Crawler {
 }
 
 pub trait DatumStream: Send + Sync {
-    async fn write(&self, crawl_datum: CrawlDatum) -> Result<()>;
-    async fn finish(&self) -> Result<()>;
+    fn write(&self, crawl_datum: CrawlDatum) -> impl Future<Output = Result<()>> + Send;
+    fn finish(&self) -> impl Future<Output = Result<()>> + Send;
 }
 
 pub fn reqwest_client(config: &CrawlerConfig) -> Result<reqwest::Client> {

--- a/core/src/crawler/mod.rs
+++ b/core/src/crawler/mod.rs
@@ -263,7 +263,6 @@ impl Crawler {
     }
 }
 
-#[async_trait::async_trait]
 pub trait DatumStream: Send + Sync {
     async fn write(&self, crawl_datum: CrawlDatum) -> Result<()>;
     async fn finish(&self) -> Result<()>;

--- a/core/src/crawler/warc_writer.rs
+++ b/core/src/crawler/warc_writer.rs
@@ -29,7 +29,6 @@ pub struct WarcWriter {
     tx: tokio::sync::mpsc::Sender<WarcWriterMessage>,
 }
 
-#[async_trait::async_trait]
 impl DatumStream for WarcWriter {
     async fn write(&self, crawl_datum: CrawlDatum) -> Result<()> {
         self.tx.send(WarcWriterMessage::Crawl(crawl_datum)).await?;

--- a/core/src/distributed/sonic/service.rs
+++ b/core/src/distributed/sonic/service.rs
@@ -29,7 +29,6 @@ pub trait Service: Sized + Send + Sync + 'static {
     async fn handle(req: Self::Request, server: &Self) -> Result<Self::Response>;
 }
 
-#[async_trait::async_trait]
 pub trait Message<S: Service> {
     type Response;
     async fn handle(self, server: &S) -> Result<Self::Response>;
@@ -291,7 +290,6 @@ mod tests {
         #[derive(Debug, Clone, Serialize, Deserialize)]
         pub struct Reset;
 
-        #[async_trait::async_trait]
         impl Message<CounterService> for Change {
             type Response = i32;
 
@@ -303,7 +301,6 @@ mod tests {
             }
         }
 
-        #[async_trait::async_trait]
         impl Message<CounterService> for Reset {
             type Response = ();
 

--- a/core/src/entrypoint/crawler.rs
+++ b/core/src/entrypoint/crawler.rs
@@ -100,7 +100,6 @@ pub mod router {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct NewJob {}
 
-    #[async_trait::async_trait]
     impl Message<RouterService> for NewJob {
         type Response = Option<Job>;
 
@@ -124,7 +123,6 @@ pub mod coordinator {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct GetJob {}
 
-    #[async_trait::async_trait]
     impl Message<CoordinatorService> for GetJob {
         type Response = Option<Job>;
 

--- a/core/src/entrypoint/live_index.rs
+++ b/core/src/entrypoint/live_index.rs
@@ -79,7 +79,6 @@ impl SearchService {
     }
 }
 
-#[async_trait::async_trait]
 impl sonic::service::Message<SearchService> for RetrieveWebsites {
     type Response = Option<Vec<inverted_index::RetrievedWebpage>>;
     async fn handle(self, server: &SearchService) -> sonic::Result<Self::Response> {
@@ -93,7 +92,6 @@ impl sonic::service::Message<SearchService> for RetrieveWebsites {
     }
 }
 
-#[async_trait::async_trait]
 impl sonic::service::Message<SearchService> for Search {
     type Response = Option<InitialWebsiteResult>;
     async fn handle(self, server: &SearchService) -> sonic::Result<Self::Response> {

--- a/core/src/entrypoint/search_server.rs
+++ b/core/src/entrypoint/search_server.rs
@@ -113,7 +113,6 @@ pub struct RetrieveWebsites {
     pub websites: Vec<inverted_index::WebsitePointer>,
     pub query: String,
 }
-#[async_trait::async_trait]
 impl sonic::service::Message<SearchService> for RetrieveWebsites {
     type Response = Option<Vec<inverted_index::RetrievedWebpage>>;
     async fn handle(self, server: &SearchService) -> sonic::Result<Self::Response> {
@@ -131,7 +130,6 @@ impl sonic::service::Message<SearchService> for RetrieveWebsites {
 pub struct Search {
     pub query: SearchQuery,
 }
-#[async_trait::async_trait]
 impl sonic::service::Message<SearchService> for Search {
     type Response = Option<InitialWebsiteResult>;
     async fn handle(self, server: &SearchService) -> sonic::Result<Self::Response> {
@@ -146,7 +144,6 @@ impl sonic::service::Message<SearchService> for Search {
 pub struct GetWebpage {
     pub url: String,
 }
-#[async_trait::async_trait]
 impl sonic::service::Message<SearchService> for GetWebpage {
     type Response = Option<RetrievedWebpage>;
     async fn handle(self, server: &SearchService) -> sonic::Result<Self::Response> {
@@ -158,7 +155,6 @@ impl sonic::service::Message<SearchService> for GetWebpage {
 pub struct GetHomepageDescriptions {
     pub urls: Vec<Url>,
 }
-#[async_trait::async_trait]
 impl sonic::service::Message<SearchService> for GetHomepageDescriptions {
     type Response = HashMap<Url, String>;
     async fn handle(self, server: &SearchService) -> sonic::Result<Self::Response> {
@@ -180,7 +176,6 @@ impl sonic::service::Message<SearchService> for GetHomepageDescriptions {
 pub struct GetEntityImage {
     pub image_id: String,
 }
-#[async_trait::async_trait]
 impl sonic::service::Message<SearchService> for GetEntityImage {
     type Response = Option<Image>;
     async fn handle(self, server: &SearchService) -> sonic::Result<Self::Response> {

--- a/core/src/entrypoint/webgraph_server.rs
+++ b/core/src/entrypoint/webgraph_server.rs
@@ -74,7 +74,6 @@ pub struct Knows {
     pub host: String,
 }
 
-#[async_trait::async_trait]
 impl Message<WebGraphService> for SimilarHosts {
     type Response = Vec<ScoredHost>;
 
@@ -110,7 +109,6 @@ impl Message<WebGraphService> for SimilarHosts {
     }
 }
 
-#[async_trait::async_trait]
 impl Message<WebGraphService> for Knows {
     type Response = Option<Node>;
 
@@ -140,7 +138,6 @@ pub struct IngoingLinks {
     pub level: GraphLevel,
 }
 
-#[async_trait::async_trait]
 impl Message<WebGraphService> for IngoingLinks {
     type Response = Vec<FullEdge>;
 
@@ -161,7 +158,6 @@ pub struct OutgoingLinks {
     pub level: GraphLevel,
 }
 
-#[async_trait::async_trait]
 impl Message<WebGraphService> for OutgoingLinks {
     type Response = Vec<FullEdge>;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,7 +22,7 @@
 // #![warn(clippy::missing_docs_in_private_items)]
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::missing_errors_doc)]
-#![feature(async_fn_in_trait)]
+#![feature(async_fn_in_trait, return_position_impl_trait_in_trait)]
 
 use std::path::PathBuf;
 use thiserror::Error;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,7 +22,6 @@
 // #![warn(clippy::missing_docs_in_private_items)]
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::missing_errors_doc)]
-#![feature(async_fn_in_trait, return_position_impl_trait_in_trait)]
 
 use std::path::PathBuf;
 use thiserror::Error;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,6 +22,7 @@
 // #![warn(clippy::missing_docs_in_private_items)]
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::missing_errors_doc)]
+#![feature(async_fn_in_trait)]
 
 use std::path::PathBuf;
 use thiserror::Error;

--- a/core/src/live_index.rs
+++ b/core/src/live_index.rs
@@ -264,7 +264,6 @@ impl Index {
     }
 }
 
-#[async_trait::async_trait]
 impl DatumStream for Indexer {
     async fn write(&self, crawl_datum: CrawlDatum) -> Result<()> {
         let webpage = self.worker.prepare_webpage(

--- a/core/src/mapreduce/worker.rs
+++ b/core/src/mapreduce/worker.rs
@@ -19,14 +19,12 @@ use std::net::SocketAddr;
 use crate::mapreduce::MapReduceServer;
 
 use super::{Map, Result, Task};
-use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 use tracing::{debug, info};
 
 #[derive(Default)]
 pub struct StatelessWorker {}
 
-#[async_trait]
 pub trait Worker {
     async fn run<I, O>(&self, addr: SocketAddr) -> Result<()>
     where


### PR DESCRIPTION
In the next Rust release we will get `async_fn_in_trait` and `return_position_impl_trait_in_trait`which removes the need for the `async-trait` crate! 🎉 

This PR performs the necessary changes in order to make the code work with these new features. ~Since they haven't been merged, the features are currently enabled with `#![feature(...)]` which obviously should be removed before this is merged.~

~One slight hiccupy is explained in https://github.com/StractOrg/stract/pull/119/commits/41c91b451434bc1026bfd50d6dc3b85777e7a181, but I think that approach is quite acceptable. Let me know what you think!~ _Edit: This seems to be quite standard practice by looking at other crates transitioning, so I don't think it's anything to worry about._