### PR TITLE
Allow multiple match statements within an optic rule

### DIFF
--- a/crates/core/src/api/explore.rs
+++ b/crates/core/src/api/explore.rs
@@ -44,14 +44,14 @@ pub async fn explore_export_optic(
         .into_iter()
         .chain(chosen_hosts.clone().into_iter())
         .map(|site| optics::Rule {
-            matches: vec![optics::Matching {
+            matches: vec![vec![optics::Matching { // TODO: these can be compressed into a single rule.
                 pattern: vec![
                     optics::PatternPart::Anchor,
                     optics::PatternPart::Raw(site),
                     optics::PatternPart::Anchor,
                 ],
                 location: optics::MatchLocation::Domain,
-            }],
+            }]],
             action: optics::Action::Boost(0),
         })
         .collect();

--- a/crates/optics/src/ast.rs
+++ b/crates/optics/src/ast.rs
@@ -101,7 +101,7 @@ pub enum RawOpticBlock {
 
 #[derive(Debug, PartialEq)]
 pub struct RawRule {
-    pub matches: RawMatchBlock,
+    pub matches: Vec<RawMatchBlock>,
     pub action: Option<RawAction>,
 }
 
@@ -196,16 +196,16 @@ mod tests {
             RawOptic {
                 rules: vec![
                     RawRule {
-                        matches: RawMatchBlock(vec![RawMatchPart::Url(
+                        matches: vec![RawMatchBlock(vec![RawMatchPart::Url(
                             "/this/is/a/*/pattern".to_string()
-                        )]),
+                        )])],
                         action: None,
                     },
                     RawRule {
-                        matches: RawMatchBlock(vec![
+                        matches: vec![RawMatchBlock(vec![
                             RawMatchPart::Url("/this/is/a/pattern".to_string()),
                             RawMatchPart::Site("example.com".to_string()),
-                        ],),
+                        ])],
                         action: None,
                     },
                 ],
@@ -250,13 +250,13 @@ mod tests {
             RawOptic {
                 rules: vec![
                     RawRule {
-                        matches: RawMatchBlock(vec![RawMatchPart::Url(
+                        matches: vec![RawMatchBlock(vec![RawMatchPart::Url(
                             "/this/is/a/*/pattern".to_string()
-                        )]),
+                        )])],
                         action: Some(RawAction::Boost(2)),
                     },
                     RawRule {
-                        matches: RawMatchBlock(vec![RawMatchPart::Site("example.com".to_string())],),
+                        matches: vec![RawMatchBlock(vec![RawMatchPart::Site("example.com".to_string())])],
                         action: Some(RawAction::Downrank(4)),
                     },
                 ],
@@ -293,13 +293,13 @@ mod tests {
             RawOptic {
                 rules: vec![
                     RawRule {
-                        matches: RawMatchBlock(vec![RawMatchPart::Url(
+                        matches: vec![RawMatchBlock(vec![RawMatchPart::Url(
                             "/this/is/a/*/pattern".to_string()
-                        )]),
+                        )])],
                         action: Some(RawAction::Boost(2)),
                     },
                     RawRule {
-                        matches: RawMatchBlock(vec![RawMatchPart::Site("example.com".to_string())],),
+                        matches: vec![RawMatchBlock(vec![RawMatchPart::Site("example.com".to_string())])],
                         action: Some(RawAction::Downrank(4)),
                     },
                 ],

--- a/crates/optics/src/parser.lalrpop
+++ b/crates/optics/src/parser.lalrpop
@@ -24,14 +24,14 @@ Block: RawOpticBlock = {
 }
 
 Rule: RawRule = {
-    "Rule" "{" <matches:RawMatchBlock> <action:RawAction?> "}" => RawRule {
+    "Rule" "{" <matches:Sep<",", RawMatchBlock>> <action:RawAction?> "}" => RawRule {
         matches,
         action
     }
 }
 
 RawMatchBlock: RawMatchBlock = {
-    "Matches" "{" <Sep<",", RawMatchPart>> "}" ","? => RawMatchBlock(<>)
+    "Matches" "{" <Sep<",", RawMatchPart>> "}" => RawMatchBlock(<>)
 }
 
 RawMatchPart: RawMatchPart = {


### PR DESCRIPTION
Current state: draft

Missing
- [x] Several conversions of rules to text create a bunch of rules that can now be simplified
- [x] Some docs/examples or something?
- [x] More tests? 1 test (pattern_same_phrase) now uses an or-rule but that's.. well, just one.

This PR makes it much easier to make large sets of rules with repeated actions. Rules can now have several `Matches` blocks. This allows Rules to essentially be an OR of several ANDs, i.e. https://en.wikipedia.org/wiki/Disjunctive_normal_form, which is much more flexible and clear. https://github.com/StractOrg/sample-optics/blob/main/10k_short.optic rewritten to use this feature would take ~256 KiB less (though that's quite an extreme example).