### PR TITLE
Bump scylla to v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,17 +420,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
-name = "bigdecimal"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e50562e37200edf7c6c43e54a08e64a5553bfb59d9c297d5572512aa517256"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,8 +1059,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -1089,14 +1088,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1138,7 +1162,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2845,17 +2869,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4088,12 +4101,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scylla"
-version = "0.9.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver?rev=82c1c99f0ff86509f9dd1e649ecdaddc5a3660cf#82c1c99f0ff86509f9dd1e649ecdaddc5a3660cf"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d2db76aa23f55d2ece5354e1a3778633098a3d1ea76153f494d71e92cd02d8"
 dependencies = [
  "arc-swap",
  "async-trait",
- "bigdecimal",
  "byteorder 1.5.0",
  "bytes",
  "chrono",
@@ -4102,7 +4115,6 @@ dependencies = [
  "histogram",
  "itertools 0.11.0",
  "lz4_flex",
- "num-bigint",
  "num_enum",
  "rand 0.8.5",
  "rand_pcg 0.3.1",
@@ -4121,16 +4133,15 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.0.8"
-source = "git+https://github.com/scylladb/scylla-rust-driver?rev=82c1c99f0ff86509f9dd1e649ecdaddc5a3660cf#82c1c99f0ff86509f9dd1e649ecdaddc5a3660cf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345626c0dd5d9624c413daaba854685bba6a65cff4eb5ea0fb0366df16901f67"
 dependencies = [
  "async-trait",
- "bigdecimal",
  "byteorder 1.5.0",
  "bytes",
  "chrono",
  "lz4_flex",
- "num-bigint",
  "num_enum",
  "scylla-macros",
  "snap",
@@ -4141,9 +4152,11 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.2.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver?rev=82c1c99f0ff86509f9dd1e649ecdaddc5a3660cf#82c1c99f0ff86509f9dd1e649ecdaddc5a3660cf"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6085ff9c3fd7e5163826901d39164ab86f11bdca16b2f766a00c528ff9cef9"
 dependencies = [
+ "darling 0.20.3",
  "proc-macro2",
  "quote",
  "syn 2.0.38",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ rusqlite = {version = "0.29.0", features = [
 rust-s3 = {version = "0.33.0", features = ["blocking", "tokio"]}
 rust-stemmers = "1.2.0"
 safetensors = "0.3.1"
-scylla = {git = "https://github.com/scylladb/scylla-rust-driver", rev = "82c1c99f0ff86509f9dd1e649ecdaddc5a3660cf"}
+scylla = {version = "0.12.0", features = ["chrono"]}
 serde = {version = "1.0.137", features = ["rc", "derive"]}
 serde_json = "1.0.81"
 serde_urlencoded = "0.7.1"

--- a/crates/core/src/improvement.rs
+++ b/crates/core/src/improvement.rs
@@ -149,10 +149,7 @@ impl ScyllaConn {
 
     async fn store_query(&self, query: StoredQuery) {
         let urls = serde_json::to_string(&query.result_urls).unwrap();
-        let timestamp = query
-            .timestamp
-            .map(|timestamp| chrono::Duration::seconds(timestamp.timestamp()))
-            .unwrap_or_else(|| chrono::Duration::seconds(0));
+        let timestamp = query.timestamp.unwrap_or_else(chrono::Utc::now);
         let qid = query.qid;
 
         let res = self
@@ -163,7 +160,7 @@ impl ScyllaConn {
                     qid,
                     query.query,
                     urls,
-                    scylla::frame::value::Timestamp(timestamp),
+                    scylla::frame::value::CqlTimestamp::from(timestamp),
                 ),
             )
             .await;


### PR DESCRIPTION
Previously we were on a fixed rev due to unreleased pull-requests (https://github.com/scylladb/scylla-rust-driver/pull/838, https://github.com/scylladb/scylla-rust-driver/pull/898), but since these are now released we can pin to a crates.io version!

v0.11 introduced a breaking change in how `scylla::frame::value`'s are represented, most importantly around timestamps. Previously the timestamp was constructed from a duration, but now it takes an actual timestamp. In the old version, `Duration::seconds(0)` was used as the default, but now we have to provide a timestamp. I'm a little but uncertain what is equivalent, but I believe `chrono::Utc::now` is what we intent to store.