### PR TITLE
Replace powf with powi

### DIFF
--- a/crates/core/src/ranking/signal.rs
+++ b/crates/core/src/ranking/signal.rs
@@ -1072,17 +1072,17 @@ impl NGramSignalOrder {
         doc: DocId,
         signal_aggregator: &'a SignalAggregator,
     ) -> impl Iterator<Item = ComputedSignal> + 'a {
-        let mut hits = 0.0;
+        let mut hits = 0;
 
         self.signals
             .iter()
             .map(|(_, s)| s)
             .filter_map(move |signal| {
                 signal.compute(signal_aggregator, doc).map(|mut c| {
-                    c.score.coefficient *= NGRAM_DAMPENING.powf(hits);
+                    c.score.coefficient *= NGRAM_DAMPENING.powi(hits);
 
                     if c.score.value > 0.0 {
-                        hits += 1.0;
+                        hits += 1;
                     }
 
                     c


### PR DESCRIPTION
Computing `powf` is a noticeable portion of search computation. However, it uses `powf` with an exponent that is always an integer. Replacing it with an actual integer reduces the time taken for this part of the computation.

Potentially it could be further improved with caching, maybe? But it's not the main bottleneck anyway, this was just really easy and free. From a quick perf test, pow has a 4x improvement (4x less samples), going from 3.21% in search_preindexed to 0.8%.