### PR TITLE
Run `cargo clippy --fix` and `cargo fmt --fix`

### DIFF
--- a/crates/core/src/api/explore.rs
+++ b/crates/core/src/api/explore.rs
@@ -43,7 +43,8 @@ pub async fn explore_export_optic(
     let matches = similar_hosts
         .into_iter()
         .chain(chosen_hosts.clone().into_iter())
-        .map(|site| vec![optics::Matching {
+        .map(|site| {
+            vec![optics::Matching {
                 pattern: vec![
                     optics::PatternPart::Anchor,
                     optics::PatternPart::Raw(site),
@@ -51,7 +52,7 @@ pub async fn explore_export_optic(
                 ],
                 location: optics::MatchLocation::Domain,
             }]
-        )
+        })
         .collect();
     let rule = optics::Rule {
         matches,

--- a/crates/core/src/collector.rs
+++ b/crates/core/src/collector.rs
@@ -142,11 +142,7 @@ impl TopSegmentCollector {
     fn get_hash(&self, doc: &DocId, field1: &FastField, field2: &FastField) -> Prehashed {
         let field_reader = self.fastfield_segment_reader.get_field_reader(doc);
 
-        let hash1 = field_reader.get(field1).into();
-
-        let hash2 = field_reader.get(field2).into();
-
-        let hash = [hash1, hash2];
+        let hash = [field_reader.get(field1), field_reader.get(field2)];
         combine_u64s(hash).into()
     }
 }

--- a/crates/core/src/entrypoint/autosuggest_scrape.rs
+++ b/crates/core/src/entrypoint/autosuggest_scrape.rs
@@ -14,12 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::fmt::Display;
 use std::{
     collections::{HashSet, VecDeque},
     path::Path,
     str::FromStr,
 };
-use std::fmt::Display;
 
 use csv::Writer;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -68,9 +68,10 @@ pub enum Gl {
 
 impl Display for Gl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
+        let code = match self {
             Gl::Us => "us",
-        })
+        };
+        write!(f, "{code}")
     }
 }
 

--- a/crates/core/src/models/bert.rs
+++ b/crates/core/src/models/bert.rs
@@ -250,7 +250,7 @@ impl BertSelfAttention {
 
         let attention_scores = query_layer.matmul(&key_layer.t()?)?;
         let attention_scores = (attention_scores / (self.attention_head_size as f64).sqrt())?;
-        let attention_scores = attention_scores.broadcast_add(&attention_mask)?;
+        let attention_scores = attention_scores.broadcast_add(attention_mask)?;
 
         let attention_probs = {
             let _enter_sm = self.span_softmax.enter();
@@ -556,7 +556,7 @@ impl BertModel {
             });
         }
 
-        let attention_mask = self.extended_attention_mask(attention_mask, &dims)?;
+        let attention_mask = self.extended_attention_mask(attention_mask, dims)?;
 
         let embedding_output = self.embeddings.forward(input_ids, token_type_ids)?;
         let sequence_output = self.encoder.forward(&embedding_output, &attention_mask)?;

--- a/crates/core/src/searcher/distributed.rs
+++ b/crates/core/src/searcher/distributed.rs
@@ -234,7 +234,7 @@ impl SearchClient for DistributedSearcher {
             .await
             .map_err(|_| Error::SearchFailed)?;
 
-        if let Some(res) = res.into_iter().flat_map(|(_, v)| v).flat_map(|v| v).next() {
+        if let Some(res) = res.into_iter().flat_map(|(_, v)| v).flatten().next() {
             Ok(Some(res))
         } else {
             Err(Error::WebpageNotFound.into())

--- a/crates/core/src/warc.rs
+++ b/crates/core/src/warc.rs
@@ -614,11 +614,7 @@ impl WarcWriter {
 
         if let Some(payload_type) = &record.response.payload_type {
             self.writer.write_all(
-                format!(
-                    "WARC-Identified-Payload-Type: {}\r\n",
-                    payload_type.to_string()
-                )
-                .as_bytes(),
+                format!("WARC-Identified-Payload-Type: {payload_type}\r\n").as_bytes(),
             )?;
         }
 

--- a/crates/core/src/webpage/safety_classifier.rs
+++ b/crates/core/src/webpage/safety_classifier.rs
@@ -35,10 +35,11 @@ pub enum Label {
 
 impl Display for Label {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
-            Label::SFW => "SFW".to_string(),
-            Label::NSFW => "NSFW".to_string(),
-        })
+        let label = match self {
+            Label::SFW => "SFW",
+            Label::NSFW => "NSFW",
+        };
+        write!(f, "{label}")
     }
 }
 

--- a/crates/kuchiki/src/serializer.rs
+++ b/crates/kuchiki/src/serializer.rs
@@ -1,7 +1,7 @@
-use std::fmt::Display;
 use html5ever::serialize::TraversalScope::*;
 use html5ever::serialize::{serialize, Serialize, SerializeOpts, Serializer, TraversalScope};
 use html5ever::QualName;
+use std::fmt::Display;
 use std::fs::File;
 use std::io::{Result, Write};
 use std::path::Path;

--- a/crates/optics/src/ast.rs
+++ b/crates/optics/src/ast.rs
@@ -14,12 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::fmt::Display;
 use super::Error;
 use super::Result as ModResult;
 use lalrpop_util::lalrpop_mod;
 use serde::Deserialize;
 use serde::Serialize;
+use std::fmt::Display;
 
 use super::lexer;
 
@@ -251,7 +251,9 @@ mod tests {
                         action: Some(RawAction::Boost(2)),
                     },
                     RawRule {
-                        matches: vec![RawMatchBlock(vec![RawMatchPart::Site("example.com".to_string())])],
+                        matches: vec![RawMatchBlock(vec![RawMatchPart::Site(
+                            "example.com".to_string()
+                        )])],
                         action: Some(RawAction::Downrank(4)),
                     },
                 ],
@@ -294,7 +296,9 @@ mod tests {
                         action: Some(RawAction::Boost(2)),
                     },
                     RawRule {
-                        matches: vec![RawMatchBlock(vec![RawMatchPart::Site("example.com".to_string())])],
+                        matches: vec![RawMatchBlock(vec![RawMatchPart::Site(
+                            "example.com".to_string()
+                        )])],
                         action: Some(RawAction::Downrank(4)),
                     },
                 ],


### PR DESCRIPTION
This PR applies the automatable fixes from `clippy` and `rustfmt`, as well as some minor refactors such as:
- Remove unnecessary explicit but inferable types.
- Move match statement of `Display` impls out of `write!` for readability.
- Use `Matching::try_from` rather than `try_into` with explicit argument.