### PR TITLE
fix: update scrolls to auto #159

### DIFF
--- a/frontend/src/routes/search/Entity.svelte
+++ b/frontend/src/routes/search/Entity.svelte
@@ -52,7 +52,7 @@
     {#if entity.relatedEntities.length > 0}
       <div class="mt-5 flex w-full flex-col text-neutral">
         <div class="font-light">Related Searches</div>
-        <div class="flex overflow-scroll">
+        <div class="flex overflow-auto">
           {#each entity.relatedEntities as related (related.title)}
             <div class="flex flex-col items-center p-4">
               {#if related.imageId != null}


### PR DESCRIPTION
This fix fixes the extra scroll on the search page, 

here is the before and after images: 

Before on desktop: 
![image](https://github.com/StractOrg/stract/assets/18273833/081c5a6d-5b06-485d-a67e-98b9be9bd6a1)

After desktop
![image](https://github.com/StractOrg/stract/assets/18273833/cdb852f0-938b-4911-9061-d5f7984cb9b2)


Before on Mobile: 
![image](https://github.com/StractOrg/stract/assets/18273833/7b8b8aaa-4683-4b4e-8667-7fb7db39d7c2)

After mobile: 
![image](https://github.com/StractOrg/stract/assets/18273833/cf17391f-876c-4d9c-8134-13a161e0bdbb)
