### PR TITLE
Fix bm25 scaling of terms based on their idf

### DIFF
--- a/crates/core/src/ranking/bm25.rs
+++ b/crates/core/src/ranking/bm25.rs
@@ -181,3 +181,28 @@ impl Bm25Weight {
         explanation
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bm25_idf_scaling() {
+        // assume the query is something like 'the end'
+        // 'the' appears in almost all docs (98)
+        // 'end' appears in a smalle subset (20)
+        let weight = MultiBm25Weight {
+            weights: vec![
+                Bm25Weight::for_one_term(98, 100, 1.0),
+                Bm25Weight::for_one_term(20, 100, 1.0),
+            ],
+        };
+
+        // if a document has high frequency of 'end'
+        // it should have a higher score than a document that
+        // has an almost equally high frequency of 'the'
+        let high_the = weight.score(vec![(0, 15), (0, 10)].into_iter());
+        let high_end = weight.score(vec![(0, 8), (0, 13)].into_iter());
+        assert!(high_end > high_the);
+    }
+}


### PR DESCRIPTION
There is currently a calculation error in the way we scale the importance of terms in bm25 based on their inverse document frequencies. The correct way is to scale each term based on their $IDF(q_i)$ but right now we erronously sum all weights and use this sum as the weight for all terms in the query. This is not the correct way to calculate bm25 as it gives too much importance to terms in the query that appears in many documents.
This PR should increase the search quality for queries like 'the sun' etc. where one of the terms is significantly less occuring, and therefore probably more important, than the other.

The search quality seems to be improved quite substantially on the development index for the query 'the sun'
This PR             |  Main branch
:-------------------------:|:-------------------------:
<img width="813" alt="Screenshot showing the search results for the query 'the sun' with the changes from this PR. Most of the results are about the word 'sun' instead of 'the'" src="https://github.com/StractOrg/stract/assets/16692368/c78c2817-9573-4ba5-8d06-46ce4ae690b7">  |  <img width="824" alt="Screenshot showing the search results for the query 'the sun' on the main branch. Most of the results are about the word 'the' instead of 'sun'" src="https://github.com/StractOrg/stract/assets/16692368/5fff213b-49af-425f-9576-61e2f49b91b1">

As the IDF weight is now unique to each term, this change comes with a minor performance hit. I've tried to benchmark this PR against the main branch to get an idea of the magnitude of the performance hit

main branch:
`Signal::compute` seems to take 28.84% of the time on examples/search_preindexed.rs

with bm25 idf fix:
`Signal::compute` seems to take 35.12% of the time on examples/search_preindexed.rs

This accounts for ~1.22x performance change compared to the main branch. The majority of the performance hit seems to come from an `imul` instruction. I suspect it's simply the `self.weight * self.tf_factor(fieldnorm_id, term_freq)` calculation in [Bm25Weight::score](https://github.com/StractOrg/stract/blob/82e050602aede28c2bd6d41a599b465cb4355729/crates/core/src/ranking/bm25.rs#L144)


Maybe we don't actually need to calculate full bm25 for fields like site, url, domain etc. but can simply calculate $$\sum_{i=1}^{n} IDF(q_i)*f_m(q_i, D)$$ where $f_m(q_i, D)$ is a mask that's 1 iff. the document $D$ contains the term $q_i$ (i.e. frequency > 0). If a term matches a document multiple times e.g in the site field, it is most likely a '.' term or something similar. Higher frequency might therefore actually not mean a result is better for these fields.
This can be implemented as a branching instruction thereby removing all floating point multiplications in the current bm25 calculation for these fields.