### PR TITLE
Parse site block rules into 'HostRankings' instead.

### DIFF
--- a/crates/core/src/query/optic.rs
+++ b/crates/core/src/query/optic.rs
@@ -1720,6 +1720,20 @@ mod tests {
             .webpages;
         assert_eq!(res.len(), 1);
         assert_eq!(res[0].url, "https://example.com/test");
+
+        let res = searcher
+            .search(&SearchQuery {
+                query: "example".to_string(),
+                optic: Some(
+                    Optic::parse("Rule { Matches { Site(\"|example.com|\") }, Action(Discard) }")
+                        .unwrap(),
+                ),
+                ..Default::default()
+            })
+            .unwrap()
+            .webpages;
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].url, "https://another-example.com/");
     }
 
     #[test]

--- a/crates/core/src/ranking/mod.rs
+++ b/crates/core/src/ranking/mod.rs
@@ -745,6 +745,19 @@ mod tests {
         let result = searcher
             .search(&SearchQuery {
                 query: "test".to_string(),
+                optic: Some(Optic {
+                    rankings: vec![
+                        RankingCoeff {
+                            target: RankingTarget::Signal("url_slashes".to_string()),
+                            value: 100_000.0,
+                        },
+                        RankingCoeff {
+                            target: RankingTarget::Signal("url_digits".to_string()),
+                            value: 100_000.0,
+                        },
+                    ],
+                    ..Default::default()
+                }),
                 ..Default::default()
             })
             .expect("Search failed");

--- a/crates/optics/src/lib.rs
+++ b/crates/optics/src/lib.rs
@@ -366,23 +366,27 @@ impl Rule {
 
         if self.action == Action::Discard {
             for matching in &self.matches {
-                if let Some(matching) = matching.first() {
-                    if matching.pattern.len() != 3 {
-                        return Vec::new();
-                    }
+                if matching.len() != 1 {
+                    return Vec::new();
+                }
 
-                    if matching.location == MatchLocation::Site
-                        && matching.pattern[0] == PatternPart::Anchor
-                        && matching.pattern[2] == PatternPart::Anchor
-                    {
-                        if let PatternPart::Raw(site) = &matching.pattern[1] {
-                            res.push(site.clone());
-                        } else {
-                            return Vec::new();
-                        }
+                let matching = &matching[0];
+
+                if matching.pattern.len() != 3 {
+                    return Vec::new();
+                }
+
+                if matching.location == MatchLocation::Site
+                    && matching.pattern[0] == PatternPart::Anchor
+                    && matching.pattern[2] == PatternPart::Anchor
+                {
+                    if let PatternPart::Raw(site) = &matching.pattern[1] {
+                        res.push(site.clone());
                     } else {
                         return Vec::new();
                     }
+                } else {
+                    return Vec::new();
                 }
             }
         }


### PR DESCRIPTION
They are still executed as exactly the same tantivy queries, but this allows us to correctly import the sites from exported optics.

Fixes the missed problem from https://github.com/StractOrg/stract/pull/167.