### PR TITLE
Top k webgraph edges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "memmap2",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2798,16 +2800,6 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
-
-[[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "memmap2"
@@ -4631,7 +4623,7 @@ dependencies = [
  "bloom",
  "file_store",
  "fst",
- "memmap",
+ "memmap2",
  "serde",
  "serde_json",
  "uuid",
@@ -4725,7 +4717,6 @@ dependencies = [
  "lz4_flex",
  "maplit",
  "md5",
- "memmap",
  "memmap2",
  "mime",
  "min-max-heap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ lz4_flex = "0.11.1"
 lzma = "0.2.2"
 maplit = "1.0.2"
 md5 = "0.7.0"
-memmap = "0.7.0"
 memmap2 = "0.9.0"
 mime = "0.3.17"
 min-max-heap = "1.3.0"
@@ -115,6 +114,7 @@ scylla = { version = "0.12.0", features = ["chrono"] }
 serde = { version = "1.0.137", features = ["rc", "derive"] }
 serde_json = "1.0.81"
 serde_urlencoded = "0.7.1"
+stable_deref_trait = "1.2.0"
 strum = { version = "0.26.2", features = ["derive"] }
 tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "74940e9" }
 thiserror = "1.0.31"

--- a/assets/licenses.html
+++ b/assets/licenses.html
@@ -44,7 +44,7 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (399)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (398)</li>
             <li><a href="#MIT">MIT License</a> (192)</li>
             <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (9)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (7)</li>
@@ -7028,7 +7028,6 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.4</a></li>
-                    <li><a href=" https://github.com/danburkert/memmap-rs ">memmap 0.7.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -68,7 +68,6 @@ logos = { workspace = true }
 lz-str = { workspace = true }
 lz4_flex = { workspace = true }
 md5 = { workspace = true }
-memmap = { workspace = true }
 memmap2 = { workspace = true }
 mime = { workspace = true }
 min-max-heap = { workspace = true }

--- a/crates/core/src/api/webgraph.rs
+++ b/crates/core/src/api/webgraph.rs
@@ -22,7 +22,7 @@ use utoipa::{IntoParams, ToSchema};
 
 use crate::{
     config::WebgraphGranularity,
-    webgraph::{FullEdge, Node},
+    webgraph::{EdgeLimit, FullEdge, Node},
 };
 
 use super::State;
@@ -219,7 +219,7 @@ async fn ingoing_links(
         WebgraphGranularity::Page => &state.page_webgraph,
     };
 
-    graph.ingoing_edges(node).await
+    graph.ingoing_edges(node, EdgeLimit::Limit(1024)).await
 }
 
 async fn outgoing_links(
@@ -232,7 +232,7 @@ async fn outgoing_links(
         WebgraphGranularity::Page => &state.page_webgraph,
     };
 
-    graph.outgoing_edges(node).await
+    graph.outgoing_edges(node, EdgeLimit::Limit(1024)).await
 }
 
 #[derive(serde::Serialize, serde::Deserialize, bincode::Encode, bincode::Decode, ToSchema)]

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -73,6 +73,7 @@ pub struct WebgraphConstructConfig {
     pub skip_warc_files: Option<usize>,
     pub batch_size: Option<usize>,
     pub canonical_index_path: Option<String>,
+    pub host_centrality_rank_store_path: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, bincode::Encode, bincode::Decode, Clone)]

--- a/crates/core/src/crawler/planner.rs
+++ b/crates/core/src/crawler/planner.rs
@@ -532,6 +532,7 @@ mod tests {
             crate::gen_temp_path(),
             Executor::single_thread(),
             Compression::default(),
+            None,
         );
 
         for (from, to, label) in edges {

--- a/crates/core/src/entrypoint/configure.rs
+++ b/crates/core/src/entrypoint/configure.rs
@@ -123,8 +123,8 @@ fn create_webgraph() -> Result<()> {
     };
 
     let mut worker = webgraph::WebgraphWorker {
-        host_graph: webgraph::open_host_graph_writer(&out_path_host),
-        page_graph: webgraph::open_page_graph_writer(&out_path_page),
+        host_graph: webgraph::open_host_graph_writer(&out_path_host, None),
+        page_graph: webgraph::open_page_graph_writer(&out_path_page, None),
         canonical_index: None,
     };
 

--- a/crates/core/src/entrypoint/webgraph_server.rs
+++ b/crates/core/src/entrypoint/webgraph_server.rs
@@ -27,6 +27,7 @@ use crate::distributed::member::Service;
 use crate::distributed::sonic::service::sonic_service;
 use crate::distributed::sonic::service::Message;
 use crate::webgraph::Edge;
+use crate::webgraph::EdgeLimit;
 use crate::webgraph::FullEdge;
 use crate::webgraph::Node;
 use crate::webgraph::NodeID;
@@ -75,78 +76,88 @@ impl Message<WebGraphService> for GetNode {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, bincode::Encode, bincode::Decode)]
 pub struct IngoingEdges {
     pub node: Node,
+    pub limit: EdgeLimit,
 }
 
 impl Message<WebGraphService> for IngoingEdges {
     type Response = Vec<FullEdge>;
 
     async fn handle(self, server: &WebGraphService) -> Self::Response {
-        server.graph.ingoing_edges(self.node)
+        server.graph.ingoing_edges(self.node, self.limit)
     }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, bincode::Encode, bincode::Decode)]
 pub struct OutgoingEdges {
     pub node: Node,
+    pub limit: EdgeLimit,
 }
 
 impl Message<WebGraphService> for OutgoingEdges {
     type Response = Vec<FullEdge>;
 
     async fn handle(self, server: &WebGraphService) -> Self::Response {
-        server.graph.outgoing_edges(self.node)
+        server.graph.outgoing_edges(self.node, self.limit)
     }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, bincode::Encode, bincode::Decode)]
 pub struct RawIngoingEdges {
     pub node: NodeID,
+    pub limit: EdgeLimit,
 }
 
 impl Message<WebGraphService> for RawIngoingEdges {
     type Response = Vec<Edge<()>>;
 
     async fn handle(self, server: &WebGraphService) -> Self::Response {
-        server.graph.raw_ingoing_edges(&self.node)
+        server.graph.raw_ingoing_edges(&self.node, self.limit)
     }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, bincode::Encode, bincode::Decode)]
 pub struct RawOutgoingEdges {
     pub node: NodeID,
+    pub limit: EdgeLimit,
 }
 
 impl Message<WebGraphService> for RawOutgoingEdges {
     type Response = Vec<Edge<()>>;
 
     async fn handle(self, server: &WebGraphService) -> Self::Response {
-        server.graph.raw_outgoing_edges(&self.node)
+        server.graph.raw_outgoing_edges(&self.node, self.limit)
     }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, bincode::Encode, bincode::Decode)]
 pub struct RawIngoingEdgesWithLabels {
     pub node: NodeID,
+    pub limit: EdgeLimit,
 }
 
 impl Message<WebGraphService> for RawIngoingEdgesWithLabels {
     type Response = Vec<Edge<String>>;
 
     async fn handle(self, server: &WebGraphService) -> Self::Response {
-        server.graph.raw_ingoing_edges_with_labels(&self.node)
+        server
+            .graph
+            .raw_ingoing_edges_with_labels(&self.node, self.limit)
     }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, bincode::Encode, bincode::Decode)]
 pub struct RawOutgoingEdgesWithLabels {
     pub node: NodeID,
+    pub limit: EdgeLimit,
 }
 
 impl Message<WebGraphService> for RawOutgoingEdgesWithLabels {
     type Response = Vec<Edge<String>>;
 
     async fn handle(self, server: &WebGraphService) -> Self::Response {
-        server.graph.raw_outgoing_edges_with_labels(&self.node)
+        server
+            .graph
+            .raw_outgoing_edges_with_labels(&self.node, self.limit)
     }
 }
 

--- a/crates/core/src/entrypoint/webgraph_server.rs
+++ b/crates/core/src/entrypoint/webgraph_server.rs
@@ -26,7 +26,6 @@ use crate::distributed::member::Member;
 use crate::distributed::member::Service;
 use crate::distributed::sonic::service::sonic_service;
 use crate::distributed::sonic::service::Message;
-use crate::webgraph::Compression;
 use crate::webgraph::Edge;
 use crate::webgraph::FullEdge;
 use crate::webgraph::Node;
@@ -171,11 +170,7 @@ pub async fn run(config: config::WebgraphServerConfig) -> Result<()> {
         .await?,
     );
 
-    let graph = Arc::new(
-        WebgraphBuilder::new(config.graph_path)
-            .compression(Compression::Lz4)
-            .open(),
-    );
+    let graph = Arc::new(WebgraphBuilder::new(config.graph_path).open());
 
     let server = WebGraphService { graph }.bind(addr).await.unwrap();
 

--- a/crates/core/src/query/optic.rs
+++ b/crates/core/src/query/optic.rs
@@ -624,6 +624,7 @@ mod tests {
             gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
+            None,
         );
 
         writer.insert(

--- a/crates/core/src/ranking/inbound_similarity.rs
+++ b/crates/core/src/ranking/inbound_similarity.rs
@@ -149,7 +149,7 @@ mod tests {
         searcher::{
             api::ApiSearcher, live::LiveSearcher, LocalSearchClient, LocalSearcher, SearchQuery,
         },
-        webgraph::{Node, Webgraph, WebgraphWriter},
+        webgraph::{EdgeLimit, Node, Webgraph, WebgraphWriter},
         webpage::{Html, Webpage},
     };
 
@@ -158,7 +158,7 @@ mod tests {
     fn inbound(graph: &Webgraph, node: &NodeID) -> bitvec_similarity::BitVec {
         bitvec_similarity::BitVec::new(
             graph
-                .raw_ingoing_edges(node)
+                .raw_ingoing_edges(node, EdgeLimit::Unlimited)
                 .into_iter()
                 .map(|e| e.from.as_u64())
                 .collect(),

--- a/crates/core/src/ranking/inbound_similarity.rs
+++ b/crates/core/src/ranking/inbound_similarity.rs
@@ -171,6 +171,7 @@ mod tests {
             gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
+            None,
         );
 
         wrt.insert(Node::from("a.com"), Node::from("b.com"), String::new());
@@ -198,6 +199,7 @@ mod tests {
             crate::gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
+            None,
         );
 
         wrt.insert(Node::from("b.com"), Node::from("a.com"), String::new());

--- a/crates/core/src/ranking/optics.rs
+++ b/crates/core/src/ranking/optics.rs
@@ -41,6 +41,7 @@ mod tests {
             gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
+            None,
         );
 
         wrt.insert(

--- a/crates/core/src/similar_hosts.rs
+++ b/crates/core/src/similar_hosts.rs
@@ -22,7 +22,7 @@ use url::Url;
 
 use crate::{
     ranking::{bitvec_similarity, inbound_similarity},
-    webgraph::{remote::RemoteWebgraph, Node, NodeID},
+    webgraph::{remote::RemoteWebgraph, EdgeLimit, Node, NodeID},
     webpage::url_ext::UrlExt,
     SortableFloat,
 };
@@ -75,7 +75,7 @@ impl SimilarHostsFinder {
 
         let in_edges = self
             .webgraph
-            .batch_raw_ingoing_edges(&nodes)
+            .batch_raw_ingoing_edges(&nodes, EdgeLimit::Limit(128))
             .await
             .unwrap_or_default();
 
@@ -88,7 +88,7 @@ impl SimilarHostsFinder {
 
         let outgoing_edges = self
             .webgraph
-            .batch_raw_outgoing_edges(&backlink_nodes)
+            .batch_raw_outgoing_edges(&backlink_nodes, EdgeLimit::Limit(4096))
             .await
             .unwrap_or_default();
 
@@ -125,7 +125,7 @@ impl SimilarHostsFinder {
         // remove dead links (nodes without outgoing edges might be dead links)
         let known_nodes = self
             .webgraph
-            .batch_raw_ingoing_edges(&potential_nodes)
+            .batch_raw_ingoing_edges(&potential_nodes, EdgeLimit::Limit(1))
             .await
             .unwrap_or_default();
 

--- a/crates/core/src/web_spell/stupid_backoff.rs
+++ b/crates/core/src/web_spell/stupid_backoff.rs
@@ -208,18 +208,18 @@ fn merge_streams(
 }
 
 pub struct StupidBackoff {
-    ngrams: fst::Map<memmap::Mmap>,
-    rotated_ngrams: fst::Map<memmap::Mmap>,
+    ngrams: fst::Map<memmap2::Mmap>,
+    rotated_ngrams: fst::Map<memmap2::Mmap>,
     n_counts: Vec<u64>,
 }
 
 impl StupidBackoff {
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let mmap = unsafe { memmap::Mmap::map(&File::open(path.as_ref().join("ngrams.bin"))?)? };
+        let mmap = unsafe { memmap2::Mmap::map(&File::open(path.as_ref().join("ngrams.bin"))?)? };
         let ngrams = fst::Map::new(mmap)?;
 
         let mmap =
-            unsafe { memmap::Mmap::map(&File::open(path.as_ref().join("rotated_ngrams.bin"))?)? };
+            unsafe { memmap2::Mmap::map(&File::open(path.as_ref().join("rotated_ngrams.bin"))?)? };
         let rotated_ngrams = fst::Map::new(mmap)?;
 
         let file = File::open(path.as_ref().join("n_counts.bin"))?;
@@ -269,7 +269,7 @@ impl StupidBackoff {
 
         merge_streams(builder, streams)?;
 
-        let mmap = unsafe { memmap::Mmap::map(&File::open(path.as_ref().join("ngrams.bin"))?)? };
+        let mmap = unsafe { memmap2::Mmap::map(&File::open(path.as_ref().join("ngrams.bin"))?)? };
         let ngrams = fst::Map::new(mmap)?;
 
         let file = OpenOptions::new()
@@ -285,7 +285,7 @@ impl StupidBackoff {
 
         merge_streams(builder, streams)?;
 
-        let mmap = unsafe { memmap::Mmap::map(&File::open(path.as_ref().join("ngrams.bin"))?)? };
+        let mmap = unsafe { memmap2::Mmap::map(&File::open(path.as_ref().join("ngrams.bin"))?)? };
         let rotated_ngrams = fst::Map::new(mmap)?;
 
         Ok(Self {

--- a/crates/core/src/web_spell/term_freqs.rs
+++ b/crates/core/src/web_spell/term_freqs.rs
@@ -71,13 +71,13 @@ impl DictBuilder {
 }
 
 struct StoredDict {
-    map: fst::Map<memmap::Mmap>,
+    map: fst::Map<memmap2::Mmap>,
     path: PathBuf,
 }
 
 impl StoredDict {
     fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let mmap = unsafe { memmap::Mmap::map(&File::open(path.as_ref())?)? };
+        let mmap = unsafe { memmap2::Mmap::map(&File::open(path.as_ref())?)? };
 
         Ok(Self {
             map: fst::Map::new(mmap)?,
@@ -147,7 +147,7 @@ impl StoredDict {
 
         builder.finish()?;
 
-        let mmap = unsafe { memmap::Mmap::map(&File::open(path.as_ref())?)? };
+        let mmap = unsafe { memmap2::Mmap::map(&File::open(path.as_ref())?)? };
 
         Ok(StoredDict {
             map: fst::Map::new(mmap)?,

--- a/crates/core/src/webgraph/builder.rs
+++ b/crates/core/src/webgraph/builder.rs
@@ -18,12 +18,11 @@ use std::path::Path;
 
 use crate::executor::Executor;
 
-use super::{Compression, Webgraph};
+use super::Webgraph;
 
 pub struct WebgraphBuilder {
     path: Box<Path>,
     executor: Executor,
-    compression: Compression,
 }
 
 impl WebgraphBuilder {
@@ -31,7 +30,6 @@ impl WebgraphBuilder {
         Self {
             path: path.as_ref().into(),
             executor: Executor::multi_thread("webgraph").unwrap(),
-            compression: Compression::default(),
         }
     }
 
@@ -40,12 +38,7 @@ impl WebgraphBuilder {
         self
     }
 
-    pub fn compression(mut self, compression: Compression) -> Self {
-        self.compression = compression;
-        self
-    }
-
     pub fn open(self) -> Webgraph {
-        Webgraph::open(self.path, self.executor, self.compression)
+        Webgraph::open(self.path, self.executor)
     }
 }

--- a/crates/core/src/webgraph/centrality/betweenness.rs
+++ b/crates/core/src/webgraph/centrality/betweenness.rs
@@ -174,6 +174,7 @@ mod tests {
             crate::gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
+            None,
         );
 
         for i in 0..n - 1 {

--- a/crates/core/src/webgraph/centrality/betweenness.rs
+++ b/crates/core/src/webgraph/centrality/betweenness.rs
@@ -23,7 +23,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::{
     intmap::IntMap,
-    webgraph::{Node, NodeID, Webgraph},
+    webgraph::{EdgeLimit, Node, NodeID, Webgraph},
 };
 
 fn calculate(graph: &Webgraph, with_progress: bool) -> (HashMap<Node, f64>, i32) {
@@ -70,7 +70,7 @@ fn calculate(graph: &Webgraph, with_progress: bool) -> (HashMap<Node, f64>, i32)
 
         while let Some(v) = q.pop_front() {
             stack.push(v);
-            for edge in graph.raw_outgoing_edges(&v) {
+            for edge in graph.raw_outgoing_edges(&v, EdgeLimit::Unlimited) {
                 let w = edge.to;
 
                 if !distances.contains_key(&w) {

--- a/crates/core/src/webgraph/centrality/derived_harmonic.rs
+++ b/crates/core/src/webgraph/centrality/derived_harmonic.rs
@@ -23,7 +23,7 @@ use bloom::U64BloomFilter;
 use rayon::prelude::*;
 use std::{collections::BTreeMap, path::Path, sync::Mutex};
 
-use crate::webgraph::{NodeID, Webgraph};
+use crate::webgraph::{EdgeLimit, NodeID, Webgraph};
 
 struct BloomMap {
     map: Vec<Mutex<U64BloomFilter>>,
@@ -101,7 +101,7 @@ impl DerivedCentrality {
 
                 if let Some(harmonic) = host_harmonic.get(&host_node).unwrap() {
                     let mut ingoing: Vec<_> = page_graph
-                        .raw_ingoing_edges(&id)
+                        .raw_ingoing_edges(&id, EdgeLimit::Limit(128))
                         .into_iter()
                         .filter_map(|e| page_graph.id2node(&e.from))
                         .map(|n| n.into_host())

--- a/crates/core/src/webgraph/centrality/harmonic.rs
+++ b/crates/core/src/webgraph/centrality/harmonic.rs
@@ -27,7 +27,7 @@ use tracing::info;
 use crate::{
     hyperloglog::HyperLogLog,
     kahan_sum::KahanSum,
-    webgraph::{NodeID, Webgraph},
+    webgraph::{EdgeLimit, NodeID, Webgraph},
 };
 
 const HYPERLOGLOG_COUNTERS: usize = 64;
@@ -66,7 +66,7 @@ fn update_changed_counters(
     let has_changes = AtomicBool::new(false);
 
     exact_changed_nodes.iter().for_each(|changed_node| {
-        for edge in graph.raw_outgoing_edges(changed_node) {
+        for edge in graph.raw_outgoing_edges(changed_node, EdgeLimit::Unlimited) {
             if let (Some(counter_to), Some(counter_from)) =
                 (counters.new.get_mut(&edge.to), counters.old.get(&edge.from))
             {

--- a/crates/core/src/webgraph/centrality/harmonic.rs
+++ b/crates/core/src/webgraph/centrality/harmonic.rs
@@ -316,6 +316,7 @@ mod tests {
             crate::gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
+            None,
         );
 
         for (from, to, label) in test_edges() {
@@ -331,6 +332,7 @@ mod tests {
             crate::gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
+            None,
         );
 
         writer.insert(
@@ -439,6 +441,7 @@ mod tests {
             crate::gen_temp_path(),
             crate::executor::Executor::single_thread(),
             crate::webgraph::Compression::default(),
+            None,
         );
 
         for (from, to, label) in test_edges() {

--- a/crates/core/src/webgraph/compression.rs
+++ b/crates/core/src/webgraph/compression.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>
 
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, bincode::Encode, bincode::Decode)]
 pub enum Compression {
     None,
     #[default]

--- a/crates/core/src/webgraph/mod.rs
+++ b/crates/core/src/webgraph/mod.rs
@@ -371,6 +371,7 @@ pub mod tests {
             crate::gen_temp_path(),
             Executor::single_thread(),
             Compression::default(),
+            None,
         );
 
         for (from, to, label) in test_edges() {
@@ -433,6 +434,7 @@ pub mod tests {
                 crate::gen_temp_path(),
                 Executor::single_thread(),
                 Compression::default(),
+                None,
             );
             wrt.insert(from.clone(), to.clone(), label.clone());
             graphs.push(wrt.finalize());
@@ -462,6 +464,7 @@ pub mod tests {
                 crate::gen_temp_path(),
                 Executor::single_thread(),
                 Compression::default(),
+                None,
             );
             wrt.insert(from.clone(), to.clone(), label.clone());
             graphs.push(wrt.finalize());
@@ -504,6 +507,7 @@ pub mod tests {
             crate::gen_temp_path(),
             Executor::single_thread(),
             Compression::default(),
+            None,
         );
 
         writer.insert(

--- a/crates/core/src/webgraph/mod.rs
+++ b/crates/core/src/webgraph/mod.rs
@@ -92,7 +92,6 @@ pub struct Webgraph {
     executor: Arc<Executor>,
     id2node: Id2NodeDb,
     meta: Meta,
-    compression: Compression,
 }
 
 impl Webgraph {
@@ -110,7 +109,7 @@ impl Webgraph {
         self.meta.save(path);
     }
 
-    fn open<P: AsRef<Path>>(path: P, executor: Executor, compression: Compression) -> Self {
+    fn open<P: AsRef<Path>>(path: P, executor: Executor) -> Self {
         fs::create_dir_all(&path).unwrap();
         let meta = Self::meta(&path);
 
@@ -121,7 +120,6 @@ impl Webgraph {
             segments.push(Segment::open(
                 path.as_ref().join("segments"),
                 segment.clone(),
-                compression,
             ));
         }
 
@@ -131,7 +129,6 @@ impl Webgraph {
             executor: Arc::new(executor),
             id2node: Id2NodeDb::open(path.as_ref().join("id2node")),
             meta,
-            compression,
         }
     }
 
@@ -147,8 +144,7 @@ impl Webgraph {
 
             self.meta.comitted_segments.push(segment.id());
             drop(segment);
-            self.segments
-                .push(Segment::open(new_path, id, self.compression));
+            self.segments.push(Segment::open(new_path, id));
         }
 
         fs::remove_dir_all(other_folder)?;

--- a/crates/core/src/webgraph/mod.rs
+++ b/crates/core/src/webgraph/mod.rs
@@ -86,6 +86,14 @@ impl Meta {
     }
 }
 
+#[derive(
+    Debug, Clone, Copy, serde::Serialize, serde::Deserialize, bincode::Encode, bincode::Decode,
+)]
+pub enum EdgeLimit {
+    Unlimited,
+    Limit(usize),
+}
+
 pub struct Webgraph {
     path: String,
     segments: Vec<Segment>,
@@ -162,14 +170,14 @@ impl Webgraph {
         self.id2node.optimize_read();
     }
 
-    pub fn ingoing_edges(&self, node: Node) -> Vec<FullEdge> {
+    pub fn ingoing_edges(&self, node: Node, limit: EdgeLimit) -> Vec<FullEdge> {
         let dedup = |edges: &mut Vec<Edge<String>>| {
             edges.sort_by_key(|e| e.from);
             edges.dedup_by_key(|e| e.from);
         };
 
         self.inner_edges(
-            |segment| segment.ingoing_edges_with_label(&node.id()),
+            |segment| segment.ingoing_edges_with_label(&node.id(), &limit),
             dedup,
         )
         .into_iter()
@@ -179,15 +187,6 @@ impl Webgraph {
             label: e.label,
         })
         .collect()
-    }
-
-    pub fn raw_ingoing_edges_by_host(&self, host_node: &NodeID) -> Vec<Edge<()>> {
-        let dedup = |edges: &mut Vec<Edge<()>>| {
-            edges.sort_by_key(|e| e.from);
-            edges.dedup_by_key(|e| e.from);
-        };
-
-        self.inner_edges(|segment| segment.ingoing_edges_by_host(host_node), dedup)
     }
 
     pub fn pages_by_host(&self, host_node: &NodeID) -> Vec<NodeID> {
@@ -208,41 +207,55 @@ impl Webgraph {
         pages
     }
 
-    pub fn raw_ingoing_edges(&self, node: &NodeID) -> Vec<Edge<()>> {
+    pub fn raw_ingoing_edges(&self, node: &NodeID, limit: EdgeLimit) -> Vec<Edge<()>> {
         let dedup = |edges: &mut Vec<Edge<()>>| {
             edges.sort_by_key(|e| e.from);
             edges.dedup_by_key(|e| e.from);
         };
 
-        self.inner_edges(|segment| segment.ingoing_edges(node), dedup)
+        self.inner_edges(|segment| segment.ingoing_edges(node, &limit), dedup)
     }
 
-    pub fn raw_ingoing_edges_with_labels(&self, node: &NodeID) -> Vec<Edge<String>> {
+    pub fn raw_ingoing_edges_with_labels(
+        &self,
+        node: &NodeID,
+        limit: EdgeLimit,
+    ) -> Vec<Edge<String>> {
         let dedup = |edges: &mut Vec<Edge<String>>| {
             edges.sort_by_key(|e| e.from);
             edges.dedup_by_key(|e| e.from);
         };
 
-        self.inner_edges(|segment| segment.ingoing_edges_with_label(node), dedup)
+        self.inner_edges(
+            |segment| segment.ingoing_edges_with_label(node, &limit),
+            dedup,
+        )
     }
 
-    pub fn raw_outgoing_edges_with_labels(&self, node: &NodeID) -> Vec<Edge<String>> {
+    pub fn raw_outgoing_edges_with_labels(
+        &self,
+        node: &NodeID,
+        limit: EdgeLimit,
+    ) -> Vec<Edge<String>> {
         let dedup = |edges: &mut Vec<Edge<String>>| {
             edges.sort_by_key(|e| e.from);
             edges.dedup_by_key(|e| e.from);
         };
 
-        self.inner_edges(|segment| segment.outgoing_edges_with_label(node), dedup)
+        self.inner_edges(
+            |segment| segment.outgoing_edges_with_label(node, &limit),
+            dedup,
+        )
     }
 
-    pub fn outgoing_edges(&self, node: Node) -> Vec<FullEdge> {
+    pub fn outgoing_edges(&self, node: Node, limit: EdgeLimit) -> Vec<FullEdge> {
         let dedup = |edges: &mut Vec<Edge<String>>| {
             edges.sort_by_key(|e| e.to);
             edges.dedup_by_key(|e| e.to);
         };
 
         self.inner_edges(
-            |segment| segment.outgoing_edges_with_label(&node.id()),
+            |segment| segment.outgoing_edges_with_label(&node.id(), &limit),
             dedup,
         )
         .into_iter()
@@ -254,13 +267,13 @@ impl Webgraph {
         .collect()
     }
 
-    pub fn raw_outgoing_edges(&self, node: &NodeID) -> Vec<Edge<()>> {
+    pub fn raw_outgoing_edges(&self, node: &NodeID, limit: EdgeLimit) -> Vec<Edge<()>> {
         let dedup = |edges: &mut Vec<Edge<()>>| {
             edges.sort_by_key(|e| e.to);
             edges.dedup_by_key(|e| e.to);
         };
 
-        self.inner_edges(|segment| segment.outgoing_edges(node), dedup)
+        self.inner_edges(|segment| segment.outgoing_edges(node, &limit), dedup)
     }
 
     fn inner_edges<F1, F2, L>(&self, loader: F1, dedup: F2) -> Vec<Edge<L>>
@@ -503,46 +516,27 @@ pub mod tests {
 
         assert_eq!(graph.segments.len(), 1);
         assert_eq!(
-            graph.outgoing_edges(Node::from("A"))[0].label,
+            graph.outgoing_edges(Node::from("A"), EdgeLimit::Unlimited)[0].label,
             "a".repeat(MAX_LABEL_LENGTH)
         );
     }
 
     #[test]
-    fn edges_by_host() {
-        let mut writer = WebgraphWriter::new(
-            crate::gen_temp_path(),
-            Executor::single_thread(),
-            Compression::default(),
-        );
-
-        writer.insert(
-            Node::from("http://a.com/first"),
-            Node::from("http://b.com/first"),
-            String::new(),
-        );
-        writer.insert(
-            Node::from("http://c.com/first"),
-            Node::from("http://b.com/second"),
-            String::new(),
-        );
-
-        let graph = writer.finalize();
-
-        let mut res = graph
-            .raw_ingoing_edges_by_host(&Node::from("b.com").id())
-            .into_iter()
-            .map(|e| e.to)
-            .map(|id| graph.id2node(&id).unwrap())
-            .collect::<Vec<_>>();
-        res.sort();
+    fn test_edge_limits() {
+        let graph = test_graph();
 
         assert_eq!(
-            res,
-            vec![
-                Node::from("http://b.com/first"),
-                Node::from("http://b.com/second")
-            ]
+            graph
+                .outgoing_edges(Node::from("A"), EdgeLimit::Unlimited)
+                .len(),
+            2
+        );
+
+        assert_eq!(
+            graph
+                .outgoing_edges(Node::from("A"), EdgeLimit::Limit(1))
+                .len(),
+            1
         );
     }
 

--- a/crates/core/src/webgraph/node.rs
+++ b/crates/core/src/webgraph/node.rs
@@ -66,16 +66,16 @@ impl From<u64> for NodeID {
     bincode::Decode,
 )]
 pub struct FullNodeID {
-    pub prefix: NodeID,
+    pub host: NodeID,
     pub id: NodeID,
 }
 
 impl From<Node> for FullNodeID {
     fn from(value: Node) -> Self {
         let id = value.id();
-        let prefix = value.into_host().id();
+        let host = value.into_host().id();
 
-        FullNodeID { prefix, id }
+        FullNodeID { host, id }
     }
 }
 

--- a/crates/core/src/webgraph/segment.rs
+++ b/crates/core/src/webgraph/segment.rs
@@ -79,20 +79,15 @@ pub struct Segment {
 }
 
 impl Segment {
-    pub fn open<P: AsRef<Path>>(folder_path: P, id: String, compression: Compression) -> Self {
+    pub fn open<P: AsRef<Path>>(folder_path: P, id: String) -> Self {
         Segment {
-            adjacency: EdgeStore::open(
-                folder_path.as_ref().join(&id).join(ADJACENCY_STORE),
-                false,
-                compression,
-            ),
+            adjacency: EdgeStore::open(folder_path.as_ref().join(&id).join(ADJACENCY_STORE), false),
             reversed_adjacency: EdgeStore::open(
                 folder_path
                     .as_ref()
                     .join(&id)
                     .join(REVERSED_ADJACENCY_STORE),
                 true,
-                compression,
             ),
             folder_path: folder_path
                 .as_ref()

--- a/crates/core/src/webgraph/shortest_path.rs
+++ b/crates/core/src/webgraph/shortest_path.rs
@@ -89,7 +89,7 @@ impl ShortestPaths for Webgraph {
     fn raw_distances_with_max(&self, source: NodeID, max_dist: u8) -> BTreeMap<NodeID, u8> {
         dijkstra_multi(
             &[source],
-            |node| self.raw_outgoing_edges(&node),
+            |node| self.raw_outgoing_edges(&node, super::EdgeLimit::Unlimited),
             |edge| edge.to,
             Some(max_dist),
         )
@@ -98,7 +98,7 @@ impl ShortestPaths for Webgraph {
     fn raw_distances(&self, source: NodeID) -> BTreeMap<NodeID, u8> {
         dijkstra_multi(
             &[source],
-            |node| self.raw_outgoing_edges(&node),
+            |node| self.raw_outgoing_edges(&node, super::EdgeLimit::Unlimited),
             |edge| edge.to,
             None,
         )
@@ -107,7 +107,7 @@ impl ShortestPaths for Webgraph {
     fn raw_reversed_distances(&self, source: NodeID) -> BTreeMap<NodeID, u8> {
         dijkstra_multi(
             &[source],
-            |node| self.raw_ingoing_edges(&node),
+            |node| self.raw_ingoing_edges(&node, super::EdgeLimit::Unlimited),
             |edge| edge.from,
             None,
         )

--- a/crates/core/src/webgraph/store_writer.rs
+++ b/crates/core/src/webgraph/store_writer.rs
@@ -19,15 +19,20 @@ pub const MAX_BATCH_SIZE: usize = 3_000_000;
 use std::{
     collections::BTreeSet,
     fs::File,
+    io::Write,
     path::{Path, PathBuf},
 };
 
 use itertools::Itertools;
+use memmap2::Mmap;
 
 use crate::Result;
 use file_store::iterable::{IterableStoreReader, SortedIterableStoreReader};
 
-use super::{store::EdgeStore, Compression, EdgeLabel, InnerEdge, NodeID};
+use super::{
+    store::{EdgeStore, PrefixDb, RangesDb},
+    Compression, EdgeLabel, InnerEdge, NodeID,
+};
 
 #[derive(bincode::Encode, bincode::Decode)]
 struct SortableEdge<L: EdgeLabel> {
@@ -101,16 +106,16 @@ pub struct EdgeStoreWriter {
 
 impl EdgeStoreWriter {
     pub fn new<P: AsRef<Path>>(path: P, compression: Compression, reversed: bool) -> Self {
-        let path = path.as_ref().join("writer");
+        let writer_path = path.as_ref().join("writer");
 
-        if !path.exists() {
-            std::fs::create_dir_all(&path).unwrap();
+        if !writer_path.exists() {
+            std::fs::create_dir_all(&writer_path).unwrap();
         }
 
         Self {
             edges: BTreeSet::new(),
             reversed,
-            path: path.to_path_buf(),
+            path: path.as_ref().to_path_buf(),
             compression,
             stored_writers: Vec::new(),
         }
@@ -119,6 +124,7 @@ impl EdgeStoreWriter {
     fn flush_to_file(&mut self) -> Result<()> {
         let file_path = self
             .path
+            .join("writer")
             .join(format!("{}.store", self.stored_writers.len()));
         let file = File::create(&file_path)?;
 
@@ -158,10 +164,7 @@ impl EdgeStoreWriter {
         let readers = self
             .stored_writers
             .iter()
-            .map(|p| {
-                let file = File::open(p).unwrap();
-                IterableStoreReader::new(file)
-            })
+            .map(|p| IterableStoreReader::open(p).unwrap())
             .collect();
         let file_reader = SortedIterableStoreReader::new(readers).map(|r| r.unwrap());
 
@@ -174,19 +177,203 @@ impl EdgeStoreWriter {
     }
 
     pub fn finalize(self) -> EdgeStore {
-        let p = self.path.parent().unwrap().to_path_buf();
+        let mut final_writer =
+            FinalEdgeStoreWriter::open(self.compression, self.reversed, &self.path);
 
-        EdgeStore::build(
-            p,
-            self.compression,
-            self.reversed,
-            self.sorted_edges().dedup().map(|e| e.edge),
-        )
+        let mut store = final_writer.build_store(self.sorted_edges().dedup().map(|e| e.edge));
+        store.optimize_read();
+
+        store
     }
 }
 
 impl Drop for EdgeStoreWriter {
     fn drop(&mut self) {
-        std::fs::remove_dir_all(&self.path).unwrap();
+        std::fs::remove_dir_all(self.path.join("writer")).unwrap();
+    }
+}
+
+struct FinalEdgeStoreWriter {
+    ranges: RangesDb,
+    prefixes: PrefixDb,
+
+    edge_labels_file: File,
+    edge_labels_len: usize,
+    edge_labels: Mmap,
+
+    edge_nodes_file: File,
+    edge_nodes_len: usize,
+    edge_nodes: Mmap,
+
+    compression: Compression,
+    reversed: bool,
+
+    path: PathBuf,
+}
+
+impl FinalEdgeStoreWriter {
+    fn open<P: AsRef<Path>>(compression: Compression, reversed: bool, path: P) -> Self {
+        let ranges = RangesDb::open(path.as_ref().join("ranges"));
+
+        let edge_labels_file = File::options()
+            .read(true)
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(path.as_ref().join("labels"))
+            .unwrap();
+        let edge_labels = unsafe { Mmap::map(&edge_labels_file).unwrap() };
+        let edge_labels_len = edge_labels.len();
+
+        let edge_nodes_file = File::options()
+            .read(true)
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(path.as_ref().join("nodes"))
+            .unwrap();
+        let edge_nodes = unsafe { Mmap::map(&edge_nodes_file).unwrap() };
+        let edge_nodes_len = edge_nodes.len();
+
+        Self {
+            ranges,
+            prefixes: PrefixDb::open(path.as_ref().join("prefixes")),
+            edge_labels,
+            edge_labels_len,
+            edge_labels_file,
+            edge_nodes,
+            edge_nodes_file,
+            edge_nodes_len,
+            reversed,
+            compression,
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+    /// Insert a batch of edges into the store.
+    /// The edges *must* have been de-duplicated by their from/to node.
+    /// I.e. if the store is not reversed, there should only ever be a single
+    /// put for each from node, and vice versa.
+    fn put_store(&mut self, edges: &[InnerEdge<String>]) {
+        if edges.is_empty() {
+            return;
+        }
+
+        let node = if self.reversed {
+            edges[0].to.clone()
+        } else {
+            edges[0].from.clone()
+        };
+
+        self.prefixes.insert(&node);
+        let node_bytes = node.id.as_u64().to_le_bytes();
+
+        debug_assert!(self.ranges.nodes_get_raw(&node_bytes).is_none());
+        debug_assert!(self.ranges.labels_get_raw(&node_bytes).is_none());
+
+        let mut edge_labels = Vec::new();
+        let mut edge_nodes = Vec::new();
+
+        for edge in edges {
+            edge_labels.push(edge.label.clone());
+            edge_nodes.push(if self.reversed {
+                edge.from.id
+            } else {
+                edge.to.id
+            });
+        }
+
+        let edge_labels_bytes =
+            bincode::encode_to_vec(&edge_labels, bincode::config::standard()).unwrap();
+        let edge_nodes_bytes =
+            bincode::encode_to_vec(&edge_nodes, bincode::config::standard()).unwrap();
+
+        let edge_labels_bytes = self.compression.compress(&edge_labels_bytes);
+        let edge_nodes_bytes = self.compression.compress(&edge_nodes_bytes);
+
+        let label_range = self.edge_labels_len..(self.edge_labels_len + edge_labels_bytes.len());
+        let node_range = self.edge_nodes_len..(self.edge_nodes_len + edge_nodes_bytes.len());
+
+        self.edge_labels_len += edge_labels_bytes.len();
+        self.edge_nodes_len += edge_nodes_bytes.len();
+
+        self.edge_labels_file.write_all(&edge_labels_bytes).unwrap();
+        self.edge_nodes_file.write_all(&edge_nodes_bytes).unwrap();
+
+        self.ranges.insert_raw_node(
+            node_bytes.to_vec(),
+            bincode::encode_to_vec(node_range, bincode::config::standard()).unwrap(),
+        );
+
+        self.ranges.insert_raw_label(
+            node_bytes.to_vec(),
+            bincode::encode_to_vec(label_range, bincode::config::standard()).unwrap(),
+        );
+    }
+
+    /// Build a new edge store from a set of edges.
+    ///
+    /// **IMPORTANT** The edges must be sorted by
+    /// either the from or to node, depending on the value of `reversed`.
+    pub fn build_store(&mut self, edges: impl Iterator<Item = InnerEdge<String>>) -> EdgeStore {
+        let mut inserts_since_last_flush = 0;
+
+        // create batches of consecutive edges with the same from/to node
+        let mut batch = Vec::new();
+        let mut last_node = None;
+        for edge in edges {
+            if let Some(last_node) = last_node {
+                if (self.reversed && edge.to.id != last_node)
+                    || (!self.reversed && edge.from.id != last_node)
+                {
+                    batch.sort_unstable_by_key(
+                        |e: &InnerEdge<_>| if self.reversed { e.from.id } else { e.to.id },
+                    );
+                    batch.dedup_by_key(|e| if self.reversed { e.from.id } else { e.to.id });
+                    let batch_len = batch.len();
+                    self.put_store(&batch);
+                    batch.clear();
+                    inserts_since_last_flush += batch_len;
+
+                    if inserts_since_last_flush >= 1_000_000 {
+                        self.flush();
+                        inserts_since_last_flush = 0;
+                    }
+                }
+            }
+
+            last_node = Some(if self.reversed {
+                edge.to.id
+            } else {
+                edge.from.id
+            });
+            batch.push(edge);
+        }
+
+        if !batch.is_empty() {
+            batch.sort_unstable_by_key(
+                |e: &InnerEdge<_>| if self.reversed { e.from.id } else { e.to.id },
+            );
+            batch.dedup_by_key(|e| if self.reversed { e.from.id } else { e.to.id });
+            self.put_store(&batch);
+        }
+
+        self.flush();
+
+        EdgeStore::open(&self.path, self.reversed, self.compression)
+    }
+
+    fn flush(&mut self) {
+        self.prefixes.flush();
+
+        self.ranges.commit();
+
+        self.edge_nodes_file.flush().unwrap();
+        self.edge_labels_file.flush().unwrap();
+
+        self.edge_nodes = unsafe { Mmap::map(&self.edge_nodes_file).unwrap() };
+        self.edge_labels = unsafe { Mmap::map(&self.edge_labels_file).unwrap() };
+
+        self.edge_nodes_len = self.edge_nodes.len();
+        self.edge_labels_len = self.edge_labels.len();
     }
 }

--- a/crates/core/src/webgraph/writer.rs
+++ b/crates/core/src/webgraph/writer.rs
@@ -29,7 +29,6 @@ pub struct WebgraphWriter {
     id2node: Id2NodeDb,
     executor: Executor,
     meta: Meta,
-    compression: Compression,
 }
 
 impl WebgraphWriter {
@@ -61,7 +60,6 @@ impl WebgraphWriter {
             id2node: Id2NodeDb::open(path.as_ref().join("id2node")),
             executor,
             meta,
-            compression,
         }
     }
 
@@ -110,7 +108,6 @@ impl WebgraphWriter {
             executor: self.executor.into(),
             id2node: self.id2node,
             meta: self.meta,
-            compression: self.compression,
         }
     }
 }

--- a/crates/core/src/webgraph/writer.rs
+++ b/crates/core/src/webgraph/writer.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses
 
-use std::{fs, path::Path};
+use std::{fs, path::Path, sync::Arc};
 
 use crate::executor::Executor;
 
@@ -42,7 +42,12 @@ impl WebgraphWriter {
         self.meta.save(path);
     }
 
-    pub fn new<P: AsRef<Path>>(path: P, executor: Executor, compression: Compression) -> Self {
+    pub fn new<P: AsRef<Path>>(
+        path: P,
+        executor: Executor,
+        compression: Compression,
+        host_centrality_rank_store: Option<Arc<speedy_kv::Db<NodeID, u64>>>,
+    ) -> Self {
         fs::create_dir_all(&path).unwrap();
         let mut meta = Self::meta(&path);
         meta.comitted_segments.clear();
@@ -50,7 +55,12 @@ impl WebgraphWriter {
         fs::create_dir_all(path.as_ref().join("segments")).unwrap();
 
         let id = uuid::Uuid::new_v4().to_string();
-        let segment = SegmentWriter::open(path.as_ref().join("segments"), id.clone(), compression);
+        let segment = SegmentWriter::open(
+            path.as_ref().join("segments"),
+            id.clone(),
+            compression,
+            host_centrality_rank_store,
+        );
 
         meta.comitted_segments.push(id);
 

--- a/crates/file-store/Cargo.toml
+++ b/crates/file-store/Cargo.toml
@@ -9,3 +9,5 @@ license = "AGPL-3.0"
 [dependencies]
 anyhow.workspace = true
 bincode.workspace = true
+memmap2.workspace = true
+stable_deref_trait.workspace = true

--- a/crates/file-store/src/const_serializable.rs
+++ b/crates/file-store/src/const_serializable.rs
@@ -12,17 +12,20 @@
 // GNU Affero General Public License for more details.
 //
 // You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>
+// along with this program.  If not, see <https://www.gnu.org/licenses/
 
-//! A collection of simple disk-based data structures.
+// change ConstSerializable to something like this
+// once generic_const_exprs is stable. See https://github.com/rust-lang/rust/issues/60551
+//
+// pub trait ConstSerializable {
+//     const BYTES: usize;
+//     fn serialize(&self) -> [u8; Self::BYTES];
+//     fn deserialize(bytes: [u8; Self::BYTES]) -> Self;
+// }
 
-pub type Result<T> = std::result::Result<T, anyhow::Error>;
+pub trait ConstSerializable {
+    const BYTES: usize;
 
-pub mod const_serializable;
-pub mod iterable;
-mod owned_bytes;
-pub mod peekable;
-pub mod random_lookup;
-
-pub use const_serializable::ConstSerializable;
-pub use peekable::Peekable;
+    fn serialize(&self, buf: &mut Vec<u8>);
+    fn deserialize(buf: &[u8]) -> Self;
+}

--- a/crates/file-store/src/const_serializable.rs
+++ b/crates/file-store/src/const_serializable.rs
@@ -26,7 +26,7 @@
 pub trait ConstSerializable {
     const BYTES: usize;
 
-    fn serialize(&self, buf: &mut Vec<u8>);
+    fn serialize(&self, buf: &mut [u8]);
     fn deserialize(buf: &[u8]) -> Self;
 }
 
@@ -35,8 +35,8 @@ macro_rules! impl_const_serializable_num {
         impl ConstSerializable for $t {
             const BYTES: usize = $n;
 
-            fn serialize(&self, buf: &mut Vec<u8>) {
-                buf.extend_from_slice(&self.to_le_bytes());
+            fn serialize(&self, buf: &mut [u8]) {
+                buf.copy_from_slice(&self.to_le_bytes());
             }
 
             fn deserialize(buf: &[u8]) -> Self {

--- a/crates/file-store/src/const_serializable.rs
+++ b/crates/file-store/src/const_serializable.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/
 
-// change ConstSerializable to something like this
+// change ConstSerializable to something like the following
 // once generic_const_exprs is stable. See https://github.com/rust-lang/rust/issues/60551
 //
 // pub trait ConstSerializable {
@@ -29,3 +29,36 @@ pub trait ConstSerializable {
     fn serialize(&self, buf: &mut Vec<u8>);
     fn deserialize(buf: &[u8]) -> Self;
 }
+
+macro_rules! impl_const_serializable_num {
+    ($t:ty, $n:expr) => {
+        impl ConstSerializable for $t {
+            const BYTES: usize = $n;
+
+            fn serialize(&self, buf: &mut Vec<u8>) {
+                buf.extend_from_slice(&self.to_le_bytes());
+            }
+
+            fn deserialize(buf: &[u8]) -> Self {
+                let mut bytes = [0; $n];
+                bytes.copy_from_slice(&buf[..$n]);
+                <$t>::from_le_bytes(bytes)
+            }
+        }
+    };
+}
+
+impl_const_serializable_num!(u8, 1);
+impl_const_serializable_num!(u16, 2);
+impl_const_serializable_num!(u32, 4);
+impl_const_serializable_num!(u64, 8);
+impl_const_serializable_num!(u128, 16);
+
+impl_const_serializable_num!(i8, 1);
+impl_const_serializable_num!(i16, 2);
+impl_const_serializable_num!(i32, 4);
+impl_const_serializable_num!(i64, 8);
+impl_const_serializable_num!(i128, 16);
+
+impl_const_serializable_num!(f32, 4);
+impl_const_serializable_num!(f64, 8);

--- a/crates/file-store/src/iterable.rs
+++ b/crates/file-store/src/iterable.rs
@@ -22,8 +22,11 @@
 //! 2. The serialized item.
 //! 3. Repeat 1-2 until the end of the file.
 
-use crate::Result;
-use std::io::{self, Read, Write};
+use crate::{owned_bytes::OwnedBytes, Result};
+use std::{
+    io::{self, Write},
+    path::Path,
+};
 
 use super::Peekable;
 
@@ -32,6 +35,11 @@ struct IterableHeader {
 }
 
 impl IterableHeader {
+    #[inline]
+    const fn serialized_size() -> usize {
+        std::mem::size_of::<u64>()
+    }
+
     fn serialize<W>(&self, writer: &mut W) -> io::Result<()>
     where
         W: io::Write,
@@ -39,16 +47,23 @@ impl IterableHeader {
         writer.write_all(&self.num_upcoming_bytes.to_le_bytes())
     }
 
-    fn deserialize<R>(reader: &mut R) -> io::Result<Self>
-    where
-        R: io::Read,
-    {
-        let mut num_upcoming_bytes = [0; 8];
-        reader.read_exact(&mut num_upcoming_bytes)?;
+    fn deserialize(bytes: &[u8]) -> io::Result<Self> {
+        if bytes.len() != Self::serialized_size() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Invalid number of bytes for IterableHeader",
+            ));
+        }
+
         Ok(IterableHeader {
-            num_upcoming_bytes: u64::from_le_bytes(num_upcoming_bytes),
+            num_upcoming_bytes: u64::from_le_bytes(bytes[..8].try_into().unwrap()),
         })
     }
+}
+
+pub struct WrittenOffset {
+    pub start: u64,
+    pub num_bytes: u64,
 }
 
 pub struct IterableStoreWriter<T, W>
@@ -56,6 +71,7 @@ where
     W: io::Write,
 {
     writer: io::BufWriter<W>,
+    next_start: u64,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -68,17 +84,27 @@ where
         Self {
             writer: io::BufWriter::new(writer),
             _marker: std::marker::PhantomData,
+            next_start: 0,
         }
     }
 
-    pub fn write(&mut self, item: &T) -> Result<()> {
+    pub fn write(&mut self, item: &T) -> Result<WrittenOffset> {
         let serialized = bincode::encode_to_vec(item, bincode::config::standard())?;
         let header = IterableHeader {
             num_upcoming_bytes: serialized.len() as u64,
         };
         header.serialize(&mut self.writer)?;
         self.writer.write_all(&serialized)?;
-        Ok(())
+
+        let start = self.next_start;
+        let bytes_written = IterableHeader::serialized_size() as u64 + serialized.len() as u64;
+
+        self.next_start += bytes_written;
+
+        Ok(WrittenOffset {
+            start,
+            num_bytes: bytes_written,
+        })
     }
 
     pub fn finalize(mut self) -> Result<W> {
@@ -88,44 +114,57 @@ where
     }
 }
 
-pub struct IterableStoreReader<T, R> {
-    reader: io::BufReader<R>,
+pub struct IterableStoreReader<T> {
+    data: OwnedBytes,
+    offset: usize,
     _marker: std::marker::PhantomData<T>,
 }
 
-impl<T, R> IterableStoreReader<T, R>
-where
-    R: io::Read,
-{
-    pub fn new(reader: R) -> Self {
+impl<T> IterableStoreReader<T> {
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let data = OwnedBytes::mmap_from_path(path)?;
+
+        Ok(Self {
+            data,
+            offset: 0,
+            _marker: std::marker::PhantomData,
+        })
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Self {
         Self {
-            reader: io::BufReader::new(reader),
+            data: OwnedBytes::new(data),
+            offset: 0,
             _marker: std::marker::PhantomData,
         }
     }
 }
 
-impl<T, R> Iterator for IterableStoreReader<T, R>
+impl<T> Iterator for IterableStoreReader<T>
 where
     T: bincode::Decode,
-    R: io::Read,
 {
     type Item = Result<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let header = match IterableHeader::deserialize(&mut self.reader) {
+        if self.offset + IterableHeader::serialized_size() >= self.data.len() {
+            return None;
+        }
+
+        let header_bytes = &self.data[self.offset..self.offset + IterableHeader::serialized_size()];
+
+        let header = match IterableHeader::deserialize(header_bytes) {
             Ok(header) => header,
             Err(_err) => return None,
         };
 
-        let mut serialized = vec![0; header.num_upcoming_bytes as usize];
-        match self.reader.read_exact(&mut serialized) {
-            Ok(()) => (),
-            Err(err) => return Some(Err(err.into())),
-        }
+        self.offset += IterableHeader::serialized_size();
+        let serialized = &self.data[self.offset..self.offset + header.num_upcoming_bytes as usize];
+
+        self.offset += header.num_upcoming_bytes as usize;
 
         Some(
-            match bincode::decode_from_slice(&serialized, bincode::config::standard()) {
+            match bincode::decode_from_slice(serialized, bincode::config::standard()) {
                 Ok((item, _)) => Ok(item),
                 Err(err) => Err(err.into()),
             },
@@ -133,30 +172,45 @@ where
     }
 }
 
-pub struct SortedIterableStoreReader<T, R>
-where
-    R: io::Read,
-    T: bincode::Decode,
-{
-    readers: Vec<Peekable<IterableStoreReader<T, R>>>,
+impl<T> io::Seek for IterableStoreReader<T> {
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        match pos {
+            io::SeekFrom::Start(offset) => {
+                self.offset = offset as usize;
+            }
+            io::SeekFrom::End(offset) => {
+                self.offset = self.data.len() - offset as usize;
+            }
+            io::SeekFrom::Current(offset) => {
+                self.offset += offset as usize;
+            }
+        }
+
+        Ok(self.offset as u64)
+    }
 }
 
-impl<T, R> SortedIterableStoreReader<T, R>
+pub struct SortedIterableStoreReader<T>
+where
+    T: bincode::Decode,
+{
+    readers: Vec<Peekable<IterableStoreReader<T>>>,
+}
+
+impl<T> SortedIterableStoreReader<T>
 where
     T: Ord + bincode::Decode,
-    R: io::Read,
 {
-    pub fn new(readers: Vec<IterableStoreReader<T, R>>) -> Self {
+    pub fn new(readers: Vec<IterableStoreReader<T>>) -> Self {
         let readers = readers.into_iter().map(Peekable::new).collect::<Vec<_>>();
 
         Self { readers }
     }
 }
 
-impl<T, R> Iterator for SortedIterableStoreReader<T, R>
+impl<T> Iterator for SortedIterableStoreReader<T>
 where
     T: Ord + bincode::Decode,
-    R: io::Read,
 {
     type Item = Result<T>;
 
@@ -170,7 +224,7 @@ where
                 match item {
                     Ok(item) => match min_index {
                         Some(cur_min) => {
-                            let cur_min_reader: &Peekable<IterableStoreReader<T, R>> =
+                            let cur_min_reader: &Peekable<IterableStoreReader<T>> =
                                 &self.readers[cur_min];
 
                             match cur_min_reader.peek().unwrap().as_ref() {
@@ -208,7 +262,7 @@ mod tests {
         writer.write(&3).unwrap();
         let writer = writer.finalize().unwrap();
 
-        let reader = IterableStoreReader::new(writer.as_slice());
+        let reader = IterableStoreReader::from_bytes(writer);
 
         let items: Vec<i32> = reader.map(|item| item.unwrap()).collect();
         assert_eq!(items, vec![1, 2, 3]);
@@ -228,9 +282,9 @@ mod tests {
         writer2.write(&6).unwrap();
         let writer2 = writer2.finalize().unwrap();
 
-        let reader1 = IterableStoreReader::new(writer1.as_slice());
+        let reader1 = IterableStoreReader::from_bytes(writer1);
 
-        let reader2 = IterableStoreReader::new(writer2.as_slice());
+        let reader2 = IterableStoreReader::from_bytes(writer2);
 
         let reader = SortedIterableStoreReader::new(vec![reader1, reader2]);
 

--- a/crates/file-store/src/lib.rs
+++ b/crates/file-store/src/lib.rs
@@ -19,6 +19,8 @@
 pub type Result<T> = std::result::Result<T, anyhow::Error>;
 
 pub mod iterable;
+mod owned_bytes;
 pub mod peekable;
+pub mod random_lookup;
 
 pub use peekable::Peekable;

--- a/crates/file-store/src/owned_bytes.rs
+++ b/crates/file-store/src/owned_bytes.rs
@@ -1,0 +1,122 @@
+// Stract is an open source web search engine.
+// Copyright (C) 2024 Stract ApS
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/
+
+use std::{fmt, io, ops::Deref, sync::Arc};
+
+use stable_deref_trait::StableDeref;
+
+// This is taken from https://docs.rs/ownedbytes/latest/ownedbytes/
+// to avoid having to pull in another dependency.
+pub struct OwnedBytes {
+    data: &'static [u8],
+    box_stable_deref: Arc<dyn Deref<Target = [u8]> + Sync + Send>,
+}
+
+impl OwnedBytes {
+    pub fn empty() -> OwnedBytes {
+        OwnedBytes::new(&[][..])
+    }
+
+    pub fn new<T: StableDeref + Deref<Target = [u8]> + 'static + Send + Sync>(
+        data_holder: T,
+    ) -> OwnedBytes {
+        let box_stable_deref = Arc::new(data_holder);
+        let bytes: &[u8] = box_stable_deref.deref();
+        let data = unsafe { &*(bytes as *const [u8]) };
+        OwnedBytes {
+            data,
+            box_stable_deref,
+        }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.data
+    }
+}
+
+impl Deref for OwnedBytes {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.data
+    }
+}
+
+impl AsRef<[u8]> for OwnedBytes {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.data
+    }
+}
+
+impl fmt::Debug for OwnedBytes {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // We truncate the bytes in order to make sure the debug string
+        // is not too long.
+        let bytes_truncated: &[u8] = if self.len() > 8 {
+            &self.as_slice()[..8]
+        } else {
+            self.as_slice()
+        };
+
+        write!(f, "OwnedBytes({bytes_truncated:?}, len={})", self.len())
+    }
+}
+
+impl Clone for OwnedBytes {
+    fn clone(&self) -> Self {
+        OwnedBytes {
+            data: self.data,
+            box_stable_deref: self.box_stable_deref.clone(),
+        }
+    }
+}
+
+impl io::Read for OwnedBytes {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.as_slice().read(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use super::*;
+
+    #[test]
+    fn test_owned_bytes() {
+        let bytes = OwnedBytes::new(vec![1, 2, 3, 4, 5]);
+        assert_eq!(bytes.len(), 5);
+        assert_eq!(bytes.as_slice(), &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_owned_bytes_empty() {
+        let bytes = OwnedBytes::empty();
+        assert_eq!(bytes.len(), 0);
+        assert_eq!(bytes.as_slice(), &[]);
+    }
+
+    #[test]
+    fn test_read() {
+        let mut bytes = OwnedBytes::new(vec![1, 2, 3, 4, 5]);
+        let mut buf = [0; 3];
+        assert_eq!(bytes.read(&mut buf).unwrap(), 3);
+        assert_eq!(&buf, &[1, 2, 3]);
+    }
+}

--- a/crates/file-store/src/owned_bytes.rs
+++ b/crates/file-store/src/owned_bytes.rs
@@ -18,7 +18,12 @@
 //! to avoid having to pull in another dependency.
 
 use stable_deref_trait::StableDeref;
-use std::{fmt, io, ops::Deref, path::Path, sync::Arc};
+use std::{
+    fmt, io,
+    ops::{Deref, Range},
+    path::Path,
+    sync::Arc,
+};
 
 pub struct OwnedBytes {
     data: &'static [u8],
@@ -51,6 +56,15 @@ impl OwnedBytes {
 
     pub fn as_slice(&self) -> &[u8] {
         self.data
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn slice(&self, range: Range<usize>) -> Self {
+        Self {
+            data: &self.data[range],
+            box_stable_deref: self.box_stable_deref.clone(),
+        }
     }
 }
 

--- a/crates/file-store/src/random_lookup.rs
+++ b/crates/file-store/src/random_lookup.rs
@@ -1,0 +1,162 @@
+// Stract is an open source web search engine.
+// Copyright (C) 2024 Stract ApS
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/
+
+use std::io::{self, Write};
+
+use crate::owned_bytes::OwnedBytes;
+
+// change ConstSerializable to something like this
+// once generic_const_exprs is stable. See https://github.com/rust-lang/rust/issues/60551
+//
+// pub trait ConstSerializable {
+//     const BYTES: usize;
+//     fn serialize(&self) -> [u8; Self::BYTES];
+//     fn deserialize(bytes: [u8; Self::BYTES]) -> Self;
+// }
+
+pub trait ConstSerializable {
+    const BYTES: usize;
+
+    fn serialize(&self, buf: &mut Vec<u8>);
+    fn deserialize(buf: &[u8]) -> Self;
+}
+
+pub struct ItemId(u64);
+
+pub struct RandomLookupWriter<V, W>
+where
+    W: io::Write,
+{
+    next_id: u64,
+    writer: io::BufWriter<W>,
+    buf: Vec<u8>,
+    _phantom: std::marker::PhantomData<V>,
+}
+
+impl<V, W> RandomLookupWriter<V, W>
+where
+    W: io::Write,
+    V: ConstSerializable,
+{
+    pub fn new(writer: W) -> Self {
+        RandomLookupWriter {
+            next_id: 0,
+            writer: io::BufWriter::new(writer),
+            buf: Vec::new(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    pub fn write(&mut self, item: &V) -> io::Result<ItemId> {
+        if self.buf.capacity() < V::BYTES {
+            self.buf.reserve(V::BYTES - self.buf.capacity());
+        }
+
+        self.buf.clear();
+
+        item.serialize(&mut self.buf);
+
+        assert_eq!(self.buf.len(), V::BYTES);
+
+        self.writer.write_all(&self.buf)?;
+
+        let id = ItemId(self.next_id);
+        self.next_id += 1;
+
+        Ok(id)
+    }
+
+    pub fn finish(mut self) -> io::Result<W> {
+        self.writer.flush()?;
+
+        Ok(self.writer.into_inner()?)
+    }
+}
+
+pub struct RandomLookup<V> {
+    data: OwnedBytes,
+    _phantom: std::marker::PhantomData<V>,
+}
+
+impl<V> RandomLookup<V>
+where
+    V: ConstSerializable,
+{
+    pub fn open(path: &std::path::Path) -> io::Result<Self> {
+        let mmap = unsafe { memmap2::Mmap::map(&std::fs::File::open(path)?)? };
+
+        let data = OwnedBytes::new(mmap);
+
+        Ok(RandomLookup {
+            data,
+            _phantom: std::marker::PhantomData,
+        })
+    }
+
+    /// Returns the value at the given item id.
+    /// Panics if the item id is not from this store.
+    pub fn get(&self, id: ItemId) -> V {
+        let item_size: usize = V::BYTES;
+
+        let start = id.0 as usize * item_size;
+
+        V::deserialize(&self.data[start..start + V::BYTES])
+    }
+}
+
+impl<V> From<OwnedBytes> for RandomLookup<V> {
+    fn from(data: OwnedBytes) -> Self {
+        RandomLookup {
+            data,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl ConstSerializable for u64 {
+        const BYTES: usize = 8;
+
+        fn serialize(&self, buf: &mut Vec<u8>) {
+            buf.extend_from_slice(&self.to_le_bytes());
+        }
+
+        fn deserialize(buf: &[u8]) -> Self {
+            let mut bytes = [0; 8];
+            bytes.copy_from_slice(&buf[..8]);
+            u64::from_le_bytes(bytes)
+        }
+    }
+
+    #[test]
+    fn test_simple() {
+        let mut writer = RandomLookupWriter::new(Vec::new());
+
+        let value = 42u64;
+
+        let id = writer.write(&value).unwrap();
+        let bytes = writer.finish().unwrap();
+
+        let store = RandomLookup::<u64>::from(OwnedBytes::new(bytes));
+
+        let value2 = store.get(id);
+
+        assert_eq!(value, value2);
+    }
+}

--- a/crates/file-store/src/random_lookup.rs
+++ b/crates/file-store/src/random_lookup.rs
@@ -115,20 +115,6 @@ impl<V> From<OwnedBytes> for RandomLookup<V> {
 mod tests {
     use super::*;
 
-    impl ConstSerializable for u64 {
-        const BYTES: usize = 8;
-
-        fn serialize(&self, buf: &mut Vec<u8>) {
-            buf.extend_from_slice(&self.to_le_bytes());
-        }
-
-        fn deserialize(buf: &[u8]) -> Self {
-            let mut bytes = [0; 8];
-            bytes.copy_from_slice(&buf[..8]);
-            u64::from_le_bytes(bytes)
-        }
-    }
-
     #[test]
     fn test_simple() {
         let mut writer = RandomLookupWriter::new(Vec::new());

--- a/crates/speedy-kv/Cargo.toml
+++ b/crates/speedy-kv/Cargo.toml
@@ -12,7 +12,7 @@ bincode.workspace = true
 bloom = { path = "../bloom" }
 file_store = { path = "../file-store" }
 fst.workspace = true
-memmap.workspace = true
+memmap2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true

--- a/crates/speedy-kv/src/blob_id_index.rs
+++ b/crates/speedy-kv/src/blob_id_index.rs
@@ -27,7 +27,7 @@ use super::{BlobId, Serialized, SerializedRef};
 
 pub struct BlobIdIndex<K> {
     path: PathBuf,
-    fst: fst::Map<memmap::Mmap>,
+    fst: fst::Map<memmap2::Mmap>,
     _marker: std::marker::PhantomData<K>,
 }
 
@@ -36,7 +36,7 @@ impl<K> BlobIdIndex<K> {
     where
         P: AsRef<Path>,
     {
-        let mmap = unsafe { memmap::Mmap::map(&std::fs::File::open(&path)?)? };
+        let mmap = unsafe { memmap2::Mmap::map(&std::fs::File::open(&path)?)? };
 
         Ok(Self {
             path: path.as_ref().to_path_buf(),

--- a/crates/speedy-kv/src/blob_index.rs
+++ b/crates/speedy-kv/src/blob_index.rs
@@ -24,7 +24,7 @@ use super::{BlobId, BlobPointer};
 
 pub struct BlobIndex {
     path: PathBuf,
-    bytes: memmap::Mmap,
+    bytes: memmap2::Mmap,
 }
 
 impl BlobIndex {
@@ -32,7 +32,7 @@ impl BlobIndex {
     where
         P: AsRef<Path>,
     {
-        let bytes = unsafe { memmap::Mmap::map(&std::fs::File::open(&path)?)? };
+        let bytes = unsafe { memmap2::Mmap::map(&std::fs::File::open(&path)?)? };
 
         Ok(Self {
             bytes,

--- a/crates/speedy-kv/src/blob_index.rs
+++ b/crates/speedy-kv/src/blob_index.rs
@@ -16,7 +16,7 @@
 
 use crate::Result;
 use std::{
-    io::{BufWriter, Write},
+    io::Write,
     path::{Path, PathBuf},
 };
 
@@ -24,7 +24,7 @@ use super::{BlobId, BlobPointer};
 
 pub struct BlobIndex {
     path: PathBuf,
-    bytes: memmap2::Mmap,
+    data: file_store::random_lookup::RandomLookup<BlobPointer>,
 }
 
 impl BlobIndex {
@@ -32,10 +32,10 @@ impl BlobIndex {
     where
         P: AsRef<Path>,
     {
-        let bytes = unsafe { memmap2::Mmap::map(&std::fs::File::open(&path)?)? };
+        let data = file_store::random_lookup::RandomLookup::open(&path)?;
 
         Ok(Self {
-            bytes,
+            data,
             path: path.as_ref().to_path_buf(),
         })
     }
@@ -45,14 +45,11 @@ impl BlobIndex {
     }
 
     pub fn get(&self, id: BlobId) -> BlobPointer {
-        let offset = id.0 as usize * BlobPointer::size();
-        let bytes = self.bytes.as_ref();
-        let bytes = &bytes[offset..offset + BlobPointer::size()];
-        BlobPointer::from_bytes(bytes.try_into().unwrap())
+        self.data.get(id.0)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = BlobPointer> + '_ {
-        BlobIndexIter::new(self.bytes.as_ref())
+        self.data.iter().map(|(_, v)| v)
     }
 
     pub fn path(&self) -> &Path {
@@ -60,42 +57,11 @@ impl BlobIndex {
     }
 }
 
-struct BlobIndexIter<'a> {
-    bytes: &'a [u8],
-    offset: usize,
-}
-
-impl<'a> BlobIndexIter<'a> {
-    fn new(bytes: &'a [u8]) -> Self {
-        Self { bytes, offset: 0 }
-    }
-}
-
-impl<'a> Iterator for BlobIndexIter<'a> {
-    type Item = BlobPointer;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.offset >= self.bytes.len() {
-            return None;
-        }
-
-        let ptr = BlobPointer::from_bytes(
-            self.bytes[self.offset..self.offset + BlobPointer::size()]
-                .try_into()
-                .unwrap(),
-        );
-        self.offset += BlobPointer::size();
-
-        Some(ptr)
-    }
-}
-
 pub struct BlobIndexWriter<W>
 where
     W: Write,
 {
-    wrt: BufWriter<W>,
-    _marker: std::marker::PhantomData<W>,
+    wrt: file_store::random_lookup::RandomLookupWriter<BlobPointer, W>,
 }
 
 impl<W> BlobIndexWriter<W>
@@ -104,18 +70,17 @@ where
 {
     pub fn new(wrt: W) -> Self {
         Self {
-            wrt: BufWriter::new(wrt),
-            _marker: std::marker::PhantomData,
+            wrt: file_store::random_lookup::RandomLookupWriter::new(wrt),
         }
     }
 
-    pub fn write(&mut self, ptr: &BlobPointer) -> Result<()> {
-        self.wrt.write_all(&ptr.as_bytes())?;
-        Ok(())
+    pub fn write(&mut self, ptr: &BlobPointer) -> Result<BlobId> {
+        let id = self.wrt.write(ptr)?;
+        Ok(BlobId(id))
     }
 
-    pub fn finish(mut self) -> Result<()> {
-        self.wrt.flush()?;
+    pub fn finish(self) -> Result<()> {
+        self.wrt.finish()?;
         Ok(())
     }
 }

--- a/crates/speedy-kv/src/blob_store.rs
+++ b/crates/speedy-kv/src/blob_store.rs
@@ -29,7 +29,7 @@ pub struct Blob<'a, K, V> {
 
 pub struct BlobStore<K, V> {
     path: PathBuf,
-    bytes: Option<memmap::Mmap>,
+    bytes: Option<memmap2::Mmap>,
     _marker: std::marker::PhantomData<(K, V)>,
 }
 
@@ -38,7 +38,7 @@ impl<K, V> BlobStore<K, V> {
     where
         P: AsRef<Path>,
     {
-        let bytes = unsafe { memmap::Mmap::map(&std::fs::File::open(path.as_ref())?).ok() };
+        let bytes = unsafe { memmap2::Mmap::map(&std::fs::File::open(path.as_ref())?).ok() };
 
         Ok(Self {
             path: path.as_ref().to_path_buf(),

--- a/crates/speedy-kv/src/lib.rs
+++ b/crates/speedy-kv/src/lib.rs
@@ -47,6 +47,7 @@ mod blob_store;
 mod segment;
 mod serialized;
 
+use file_store::ConstSerializable;
 pub use serialized::{Serialized, SerializedRef};
 
 struct BlobPointer {
@@ -93,8 +94,20 @@ impl BlobPointer {
     }
 }
 
+impl ConstSerializable for BlobPointer {
+    const BYTES: usize = Self::size();
+
+    fn serialize(&self, buf: &mut [u8]) {
+        buf.copy_from_slice(&self.as_bytes());
+    }
+
+    fn deserialize(buf: &[u8]) -> Self {
+        Self::from_bytes(buf.try_into().unwrap())
+    }
+}
+
 #[derive(Clone, Copy)]
-struct BlobId(u64);
+struct BlobId(file_store::random_lookup::ItemId);
 
 #[derive(Debug)]
 struct LiveSegment<K, V> {

--- a/crates/speedy-kv/src/segment.rs
+++ b/crates/speedy-kv/src/segment.rs
@@ -63,9 +63,9 @@ where
     W: Write,
 {
     fn insert(&mut self, key: SerializedRef<'_, K>, value: SerializedRef<'_, V>) -> Result<()> {
-        let _id = self.writers.id_index.insert(key.as_bytes())?;
         let ptr = self.writers.store.write(key, value)?;
-        self.writers.blob_index.write(&ptr)?;
+        let id = self.writers.blob_index.write(&ptr)?;
+        self.writers.id_index.insert(key.as_bytes(), &id)?;
 
         self.bloom.insert_raw(key.as_bytes());
 


### PR DESCRIPTION
Changes the webgraph file format so we can retrieve top edges based on the host centrality rank of the other node. This speeds up a lot of downstream tasks like indexing as we can choose how many edges we are interested in reading from disk and send over the network from the remote webgraph to the indexer.