### PR TITLE
Live index replication

### DIFF
--- a/crates/core/src/block_on.rs
+++ b/crates/core/src/block_on.rs
@@ -1,0 +1,30 @@
+// Stract is an open source web search engine.
+// Copyright (C) 2024 Stract ApS
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+static TOKIO_RUNTIME: std::sync::LazyLock<tokio::runtime::Runtime> =
+    std::sync::LazyLock::new(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    });
+
+pub fn block_on<F>(f: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    TOKIO_RUNTIME.block_on(f)
+}

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -472,9 +472,6 @@ pub struct CrawlPlannerConfig {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub struct LiveIndexConfig {
-    pub split_path: String,
-    pub downloaded_db_path: String,
-
     // crawler
     pub user_agent: UserAgent,
     #[serde(default = "defaults::Crawler::robots_txt_cache_sec")]
@@ -496,7 +493,6 @@ pub struct LiveIndexConfig {
 
     // indexer
     pub host_centrality_store_path: String,
-    pub page_webgraph: Option<IndexerGraphConfig>,
     pub page_centrality_store_path: Option<String>,
     pub safety_classifier_path: Option<String>,
     pub host_centrality_threshold: Option<f64>,

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -19,7 +19,6 @@ pub mod defaults;
 use super::Result;
 use crate::ampc::dht;
 use crate::distributed::member::ShardId;
-use crate::feed::scheduler::SplitId;
 
 use std::fs::File;
 use std::io::{self, BufRead};
@@ -507,7 +506,7 @@ pub struct LiveIndexConfig {
     pub cluster_id: String,
     pub gossip_seed_nodes: Option<Vec<SocketAddr>>,
     pub gossip_addr: SocketAddr,
-    pub split_id: SplitId,
+    pub shard_id: ShardId,
     pub index_path: String,
     pub linear_model_path: Option<String>,
     pub lambda_model_path: Option<String>,

--- a/crates/core/src/distributed/cluster.rs
+++ b/crates/core/src/distributed/cluster.rs
@@ -211,7 +211,7 @@ impl Cluster {
         self.self_node.as_ref()
     }
 
-    pub async fn set_service(&mut self, service: Service) -> Result<()> {
+    pub async fn set_service(&self, service: Service) -> Result<()> {
         self.chitchat
             .lock()
             .await

--- a/crates/core/src/distributed/member.rs
+++ b/crates/core/src/distributed/member.rs
@@ -73,6 +73,31 @@ impl From<ShardId> for u64 {
     Clone,
     Debug,
 )]
+pub enum LiveIndexState {
+    InSetup,
+    Ready,
+}
+
+impl std::fmt::Display for LiveIndexState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LiveIndexState::InSetup => write!(f, "setup"),
+            LiveIndexState::Ready => write!(f, "ready"),
+        }
+    }
+}
+
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    bincode::Encode,
+    bincode::Decode,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Debug,
+)]
 pub enum Service {
     Searcher {
         host: SocketAddr,
@@ -83,7 +108,8 @@ pub enum Service {
     },
     LiveIndex {
         host: SocketAddr,
-        split_id: crate::feed::scheduler::SplitId,
+        shard: ShardId,
+        state: LiveIndexState,
     },
     Api {
         host: SocketAddr,
@@ -118,7 +144,9 @@ impl std::fmt::Display for Service {
         match self {
             Self::Searcher { host, shard } => write!(f, "Searcher {} {}", host, shard),
             Self::EntitySearcher { host } => write!(f, "EntitySearcher {}", host),
-            Self::LiveIndex { host, split_id } => write!(f, "LiveIndex {} {}", host, split_id),
+            Self::LiveIndex { host, shard, state } => {
+                write!(f, "LiveIndex {} {} {}", host, shard, state)
+            }
             Self::Api { host } => write!(f, "Api {}", host),
             Self::Webgraph {
                 host,

--- a/crates/core/src/distributed/mod.rs
+++ b/crates/core/src/distributed/mod.rs
@@ -17,3 +17,4 @@ pub mod cluster;
 pub mod member;
 pub mod retry_strategy;
 pub mod sonic;
+pub mod remote_cp;

--- a/crates/core/src/distributed/remote_cp.rs
+++ b/crates/core/src/distributed/remote_cp.rs
@@ -22,7 +22,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-const CHUNK_SIZE_BYTES: usize = 1024 * 1024 * 1024; // 1 MB
+const CHUNK_SIZE_BYTES: usize = 1024 * 1024; // 1 MB
 
 pub trait Stepper {
     fn step(&self, req: Request) -> impl Future<Output = Response>;
@@ -282,5 +282,8 @@ mod tests {
 
         let res = std::fs::read_to_string(b.join("plus_1.txt")).unwrap();
         assert_eq!(format!("{}aa", &content), res);
+
+        std::fs::remove_dir_all(&a).unwrap();
+        std::fs::remove_dir_all(&b).unwrap();
     }
 }

--- a/crates/core/src/distributed/remote_cp.rs
+++ b/crates/core/src/distributed/remote_cp.rs
@@ -1,0 +1,202 @@
+// Stract is an open source web search engine.
+// Copyright (C) 2023 Stract ApS
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::Result;
+use std::{
+    fs,
+    io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+};
+
+const CHUNK_SIZE_BYTES: usize = 1024 * 1024 * 1024; // 1 MB
+
+enum Request {
+    Overview { root: PathBuf },
+    Chunk { path: PathBuf, offset: u64 },
+}
+
+impl Request {
+    pub fn download<P1, P2, F>(remote_path: P1, to: P2, step: F)
+    where
+        P1: AsRef<Path>,
+        P2: AsRef<Path>,
+        F: Fn(Self) -> Response,
+    {
+        let Response::Overview { paths } = step(Self::Overview {
+            root: remote_path.as_ref().to_path_buf(),
+        }) else {
+            panic!("unexpected response to request")
+        };
+
+        for path in paths {
+            let local = to.as_ref().join(path.clone());
+            if let Some(parent) = local.parent() {
+                if !parent.exists() {
+                    fs::create_dir_all(parent).expect("failed to create directory");
+                }
+            }
+
+            Self::download_file(remote_path.as_ref().join(path.clone()), local, &step);
+        }
+    }
+
+    pub fn download_file<P1, P2, F>(remote: P1, local: P2, step: F)
+    where
+        P1: AsRef<Path>,
+        P2: AsRef<Path>,
+        F: Fn(Self) -> Response,
+    {
+        let mut offset = 0;
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(local.as_ref())
+            .expect(&format!(
+                "failed to create file {:?}",
+                local.as_ref().as_os_str()
+            ));
+        let mut writer = BufWriter::new(file);
+
+        loop {
+            let Response::Chunk { bytes } = step(Self::Chunk {
+                path: remote.as_ref().to_path_buf(),
+                offset,
+            }) else {
+                panic!("unexpected response to request");
+            };
+
+            writer.write_all(&bytes).unwrap();
+
+            if bytes.len() < CHUNK_SIZE_BYTES {
+                break;
+            }
+
+            offset += bytes.len() as u64;
+        }
+    }
+}
+
+enum Response {
+    Overview { paths: Vec<PathBuf> },
+    Chunk { bytes: Vec<u8> },
+}
+
+impl Response {
+    pub fn handle(req: Request) -> Result<Self> {
+        match req {
+            Request::Overview { root } => Ok(Response::Overview {
+                paths: files(root.clone())
+                    .into_iter()
+                    .filter_map(|p| p.strip_prefix(&root).ok().map(|p| p.to_path_buf()))
+                    .collect(),
+            }),
+            Request::Chunk { path, offset } => {
+                let file = fs::File::open(path)?;
+                let mut reader = BufReader::new(file);
+
+                reader.seek(SeekFrom::Start(offset)).ok();
+
+                let mut res = Vec::with_capacity(CHUNK_SIZE_BYTES);
+                let mut buf = [0; 512];
+
+                while res.len() < CHUNK_SIZE_BYTES {
+                    let n = reader.read(&mut buf)?;
+
+                    if n == 0 {
+                        break;
+                    }
+
+                    res.extend_from_slice(&buf[..n]);
+                }
+
+                Ok(Response::Chunk { bytes: res })
+            }
+        }
+    }
+}
+
+fn files(root: PathBuf) -> Vec<PathBuf> {
+    let mut stack = vec![root];
+    let mut res = Vec::new();
+
+    while let Some(path) = stack.pop() {
+        if path.is_file() {
+            res.push(path);
+        } else {
+            if let Ok(dir) = fs::read_dir(path) {
+                for entry in dir {
+                    if let Ok(entry) = entry {
+                        stack.push(entry.path());
+                    }
+                }
+            }
+        }
+    }
+
+    res
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use file_store::gen_temp_path;
+
+    use super::*;
+
+    fn local_step(req: Request) -> Response {
+        Response::handle(req).unwrap()
+    }
+
+    fn download<P1: AsRef<Path>, P2: AsRef<Path>>(remote: P1, local: P2) {
+        Request::download(remote, local, local_step)
+    }
+
+    #[test]
+    fn test_directory() {
+        let a = gen_temp_path();
+        std::fs::create_dir_all(a.join("test")).unwrap();
+        let contents = "this is a test";
+        std::fs::write(a.join("test").join("file.txt"), contents).unwrap();
+
+        let b = gen_temp_path();
+        download(&a, &b);
+
+        assert!(b.join("test").exists());
+        assert!(b.join("test").join("file.txt").exists());
+
+        let res = std::fs::read_to_string(b.join("test").join("file.txt")).unwrap();
+
+        assert_eq!(contents, res);
+    }
+
+    #[test]
+    fn test_single_file() {
+        let a = gen_temp_path();
+        std::fs::create_dir_all(&a).unwrap();
+        let contents = "this is a test";
+        std::fs::write(a.join("file.txt"), contents).unwrap();
+
+        let b = gen_temp_path();
+        download(&a, &b);
+
+        assert!(b.join("file.txt").exists());
+
+        let res = std::fs::read_to_string(b.join("file.txt")).unwrap();
+
+        assert_eq!(contents, res);
+    }
+}

--- a/crates/core/src/entrypoint/configure.rs
+++ b/crates/core/src/entrypoint/configure.rs
@@ -185,26 +185,29 @@ fn create_inverted_index() -> Result<()> {
         Some(dual_encoder_path)
     };
 
-    let worker = indexer::IndexingWorker::new(IndexerConfig {
-        host_centrality_store_path: centrality_path.to_str().unwrap().to_string(),
-        page_centrality_store_path: Some(page_centrality_path.to_str().unwrap().to_string()),
-        page_webgraph: Some(IndexerGraphConfig::Local {
-            path: webgraph_path.to_str().unwrap().to_string(),
-        }),
-        output_path: out_path.to_str().unwrap().to_string(),
-        limit_warc_files: None,
-        skip_warc_files: None,
-        warc_source: job.source_config.clone(),
-        host_centrality_threshold: None,
-        safety_classifier_path: None,
-        minimum_clean_words: None,
-        batch_size: defaults::Indexing::batch_size(),
-        autocommit_after_num_inserts: defaults::Indexing::autocommit_after_num_inserts(),
-        dual_encoder: dual_encoder_path.map(|p| IndexerDualEncoderConfig {
-            model_path: p.to_str().unwrap().to_string(),
-            page_centrality_rank_threshold: Some(100_000),
-        }),
-    });
+    let worker = indexer::IndexingWorker::new(
+        IndexerConfig {
+            host_centrality_store_path: centrality_path.to_str().unwrap().to_string(),
+            page_centrality_store_path: Some(page_centrality_path.to_str().unwrap().to_string()),
+            page_webgraph: Some(IndexerGraphConfig::Local {
+                path: webgraph_path.to_str().unwrap().to_string(),
+            }),
+            output_path: out_path.to_str().unwrap().to_string(),
+            limit_warc_files: None,
+            skip_warc_files: None,
+            warc_source: job.source_config.clone(),
+            host_centrality_threshold: None,
+            safety_classifier_path: None,
+            minimum_clean_words: None,
+            batch_size: defaults::Indexing::batch_size(),
+            autocommit_after_num_inserts: defaults::Indexing::autocommit_after_num_inserts(),
+            dual_encoder: dual_encoder_path.map(|p| IndexerDualEncoderConfig {
+                model_path: p.to_str().unwrap().to_string(),
+                page_centrality_rank_threshold: Some(100_000),
+            }),
+        }
+        .into(),
+    );
 
     let index = job.process(&worker);
     crate::mv(index.path(), &out_path)?;

--- a/crates/core/src/entrypoint/configure.rs
+++ b/crates/core/src/entrypoint/configure.rs
@@ -185,7 +185,7 @@ fn create_inverted_index() -> Result<()> {
         Some(dual_encoder_path)
     };
 
-    let worker = indexer::IndexingWorker::new(
+    let worker = crate::block_on(indexer::IndexingWorker::new(
         IndexerConfig {
             host_centrality_store_path: centrality_path.to_str().unwrap().to_string(),
             page_centrality_store_path: Some(page_centrality_path.to_str().unwrap().to_string()),
@@ -207,7 +207,7 @@ fn create_inverted_index() -> Result<()> {
             }),
         }
         .into(),
-    );
+    ));
 
     let index = job.process(&worker);
     crate::mv(index.path(), &out_path)?;

--- a/crates/core/src/entrypoint/indexer/job.rs
+++ b/crates/core/src/entrypoint/indexer/job.rs
@@ -85,7 +85,7 @@ impl Job {
                     batch.push(IndexableWebpage::from(record));
                 }
 
-                let prepared = worker.prepare_webpages(&batch);
+                let prepared = crate::block_on(worker.prepare_webpages(&batch));
 
                 for webpage in &prepared {
                     if webpage.host_centrality > 0.0 {

--- a/crates/core/src/entrypoint/indexer/mod.rs
+++ b/crates/core/src/entrypoint/indexer/mod.rs
@@ -45,7 +45,7 @@ pub fn run(config: &config::IndexerConfig) -> Result<()> {
 
     let job_config: WarcSource = config.warc_source.clone();
 
-    let worker = IndexingWorker::new(config.clone());
+    let worker = IndexingWorker::new(config.clone().into());
 
     let indexes = warc_paths
         .into_par_iter()

--- a/crates/core/src/entrypoint/indexer/mod.rs
+++ b/crates/core/src/entrypoint/indexer/mod.rs
@@ -45,7 +45,7 @@ pub fn run(config: &config::IndexerConfig) -> Result<()> {
 
     let job_config: WarcSource = config.warc_source.clone();
 
-    let worker = IndexingWorker::new(config.clone().into());
+    let worker = crate::block_on(IndexingWorker::new(config.clone().into()));
 
     let indexes = warc_paths
         .into_par_iter()

--- a/crates/core/src/entrypoint/indexer/worker.rs
+++ b/crates/core/src/entrypoint/indexer/worker.rs
@@ -172,12 +172,7 @@ pub struct IndexingWorker {
 }
 
 impl IndexingWorker {
-    pub fn new<C>(config: C) -> Self
-    where
-        Config: From<C>,
-    {
-        let config = Config::from(config);
-
+    pub fn new(config: Config) -> Self {
         let host_centrality_rank_store = speedy_kv::Db::open_or_create(
             Path::new(&config.host_centrality_store_path).join("harmonic_rank"),
         )
@@ -486,28 +481,31 @@ mod tests {
     use super::*;
 
     fn setup_worker(data_path: &Path, threshold: Option<u64>) -> IndexingWorker {
-        IndexingWorker::new(IndexerConfig {
-            host_centrality_store_path: crate::gen_temp_path().to_str().unwrap().to_string(),
-            page_centrality_store_path: None,
-            page_webgraph: None,
-            safety_classifier_path: None,
-            dual_encoder: Some(IndexerDualEncoderConfig {
-                model_path: data_path.to_str().unwrap().to_string(),
-                page_centrality_rank_threshold: threshold,
-            }),
-            output_path: crate::gen_temp_path().to_str().unwrap().to_string(),
-            limit_warc_files: None,
-            skip_warc_files: None,
-            warc_source: WarcSource::Local(crate::config::LocalConfig {
-                folder: crate::gen_temp_path().to_str().unwrap().to_string(),
-                names: vec!["".to_string()],
-            }),
-            host_centrality_threshold: None,
-            minimum_clean_words: None,
-            batch_size: 10,
-            autocommit_after_num_inserts:
-                crate::config::defaults::Indexing::autocommit_after_num_inserts(),
-        })
+        IndexingWorker::new(
+            IndexerConfig {
+                host_centrality_store_path: crate::gen_temp_path().to_str().unwrap().to_string(),
+                page_centrality_store_path: None,
+                page_webgraph: None,
+                safety_classifier_path: None,
+                dual_encoder: Some(IndexerDualEncoderConfig {
+                    model_path: data_path.to_str().unwrap().to_string(),
+                    page_centrality_rank_threshold: threshold,
+                }),
+                output_path: crate::gen_temp_path().to_str().unwrap().to_string(),
+                limit_warc_files: None,
+                skip_warc_files: None,
+                warc_source: WarcSource::Local(crate::config::LocalConfig {
+                    folder: crate::gen_temp_path().to_str().unwrap().to_string(),
+                    names: vec!["".to_string()],
+                }),
+                host_centrality_threshold: None,
+                minimum_clean_words: None,
+                batch_size: 10,
+                autocommit_after_num_inserts:
+                    crate::config::defaults::Indexing::autocommit_after_num_inserts(),
+            }
+            .into(),
+        )
     }
 
     #[test]

--- a/crates/core/src/entrypoint/live_index.rs
+++ b/crates/core/src/entrypoint/live_index.rs
@@ -59,13 +59,16 @@ impl LiveIndexService {
                 id: config.cluster_id,
                 service: Service::LiveIndex {
                     host: config.host,
-                    split_id: config.split_id,
+                    shard: config.shard_id,
+                    state: crate::distributed::member::LiveIndexState::InSetup,
                 },
             },
             config.gossip_addr,
             config.gossip_seed_nodes.unwrap_or_default(),
         )
         .await?;
+
+        todo!("check if there are other nodes in cluster with same shard and download index from them if this is the case");
 
         Ok(Self {
             local_searcher,
@@ -101,7 +104,9 @@ impl sonic::service::Message<LiveIndexService> for IndexWebpages {
     type Response = ();
 
     async fn handle(self, server: &LiveIndexService) -> Self::Response {
-        server.index.insert(&self.pages)
+        server.index.insert(&self.pages);
+
+        todo!("send write to all other replicas and make sure we get response from `config.consistency_fraction` before succeeding");
     }
 }
 

--- a/crates/core/src/entrypoint/live_index/mod.rs
+++ b/crates/core/src/entrypoint/live_index/mod.rs
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(test)]
+mod tests;
+
 use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
@@ -339,8 +342,8 @@ pub enum IndexingError {
 
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode)]
 pub struct IndexWebpages {
-    pages: Vec<IndexableWebpage>,
-    consistency_fraction: Option<f64>,
+    pub pages: Vec<IndexableWebpage>,
+    pub consistency_fraction: Option<f64>,
 }
 
 impl sonic::service::Message<LiveIndexService> for IndexWebpages {

--- a/crates/core/src/entrypoint/live_index/tests.rs
+++ b/crates/core/src/entrypoint/live_index/tests.rs
@@ -1,0 +1,158 @@
+// Stract is an open source web search engine.
+// Copyright (C) 2023 Stract ApS
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{live_index::LiveIndex, Result};
+use std::{net::SocketAddr, sync::Arc};
+
+use tokio::task::JoinHandle;
+
+use crate::{
+    ampc::dht::ShardId,
+    distributed::{
+        cluster::Cluster,
+        member::{LiveIndexState, Service},
+        sonic,
+    },
+    entrypoint::{indexer::IndexableWebpage, live_index::IndexWebpages},
+    free_socket_addr,
+};
+
+use super::LiveIndexService;
+
+struct RemoteIndex {
+    host: SocketAddr,
+    shard: ShardId,
+    gossip_addr: SocketAddr,
+    underlying_index: Arc<LiveIndex>,
+    handle: JoinHandle<()>,
+}
+
+impl RemoteIndex {
+    async fn conn(&self) -> Result<sonic::service::Connection<LiveIndexService>> {
+        Ok(sonic::service::Connection::create(self.host).await?)
+    }
+
+    async fn index_pages(
+        &self,
+        pages: Vec<IndexableWebpage>,
+        consistency_fraction: Option<f64>,
+    ) -> Result<()> {
+        self.conn()
+            .await?
+            .send(IndexWebpages {
+                pages,
+                consistency_fraction,
+            })
+            .await??;
+
+        Ok(())
+    }
+
+    async fn await_ready(&self, cluster: &Cluster) {
+        cluster
+            .await_member(|member| {
+                if let Service::LiveIndex {
+                    host: _,
+                    shard,
+                    state,
+                } = member.service.clone()
+                {
+                    self.shard == shard && matches!(state, LiveIndexState::Ready)
+                } else {
+                    false
+                }
+            })
+            .await;
+    }
+
+    async fn commit_underlying(&self) -> Result<()> {
+        let index = Arc::clone(&self.underlying_index);
+        tokio::task::spawn_blocking(move || index.commit()).await?;
+
+        Ok(())
+    }
+}
+
+const CLUSTER_ID: &str = "test-cluster";
+
+async fn start_index(shard: ShardId, gossip: Vec<SocketAddr>) -> Result<RemoteIndex> {
+    todo!()
+}
+
+#[tokio::test]
+async fn test_shard_without_replica() -> Result<()> {
+    let shard1 = start_index(ShardId::new(1), vec![]).await?;
+    let shard2 = start_index(ShardId::new(2), vec![shard1.gossip_addr]).await?;
+
+    let cluster = Cluster::join_as_spectator(
+        CLUSTER_ID.to_string(),
+        free_socket_addr(),
+        vec![shard1.gossip_addr],
+    )
+    .await?;
+
+    shard1.await_ready(&cluster).await;
+    shard2.await_ready(&cluster).await;
+
+    shard1
+        .index_pages(
+            vec![IndexableWebpage {
+                url: "https://a.com/".to_string(),
+                body: "
+                <title>test page</title>
+                Example webpage
+                "
+                .to_string(),
+                fetch_time_ms: 100,
+            }],
+            None,
+        )
+        .await?;
+    shard2
+        .index_pages(
+            vec![IndexableWebpage {
+                url: "https://b.com/".to_string(),
+                body: "
+                <title>test page</title>
+                Example webpage
+                "
+                .to_string(),
+                fetch_time_ms: 100,
+            }],
+            None,
+        )
+        .await?;
+
+    shard1.commit_underlying().await?;
+    shard2.commit_underlying().await?;
+
+    todo!("test searches");
+}
+
+#[tokio::test]
+async fn test_replica_no_fails() -> Result<()> {
+    todo!("start cluster with shard1_rep1 and shard1_rep2, insert some pages and check they are all indexed");
+}
+
+#[tokio::test]
+async fn test_replica_setup_after_inserts() -> Result<()> {
+    todo!("start cluser with shard1_rep1, insert page, start shard1_rep2, check that shard1_rep2 has page");
+}
+
+#[tokio::test]
+async fn test_replica_recovery() -> Result<()> {
+    todo!("start cluser with shard1_rep1 shard1_rep2, insert page, kill shard1_rep2, insert another page, start shard1_rep2, check that shard1_rep2 has both pages");
+}

--- a/crates/core/src/entrypoint/live_index/tests.rs
+++ b/crates/core/src/entrypoint/live_index/tests.rs
@@ -14,10 +14,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{live_index::LiveIndex, Result};
+use crate::{
+    config::LiveIndexConfig, entrypoint::search_server, inverted_index, live_index::LiveIndex,
+    Result,
+};
 use std::{net::SocketAddr, sync::Arc};
 
-use tokio::task::JoinHandle;
+use file_store::gen_temp_path;
 
 use crate::{
     ampc::dht::ShardId,
@@ -37,10 +40,82 @@ struct RemoteIndex {
     shard: ShardId,
     gossip_addr: SocketAddr,
     underlying_index: Arc<LiveIndex>,
-    handle: JoinHandle<()>,
+    cluster: Arc<Cluster>,
 }
 
 impl RemoteIndex {
+    async fn start(shard: ShardId, gossip_seed: Vec<SocketAddr>) -> Result<Self> {
+        let path = gen_temp_path();
+
+        let host = free_socket_addr();
+        let gossip_addr = free_socket_addr();
+
+        let gossip_seed = if gossip_seed.is_empty() {
+            None
+        } else {
+            Some(gossip_seed)
+        };
+
+        let config = LiveIndexConfig {
+            user_agent: crate::config::UserAgent {
+                full: "TestBot".to_string(),
+                token: "TestBot".to_string(),
+            },
+            robots_txt_cache_sec: 60 * 60,
+            min_politeness_factor: 1,
+            start_politeness_factor: 3,
+            min_crawl_delay_ms: 5_000,
+            max_crawl_delay_ms: 60_000,
+            max_politeness_factor: 2048,
+            max_url_slowdown_retry: 5,
+            timeout_seconds: 30,
+            host_centrality_store_path: path
+                .as_path()
+                .join("host_centrality")
+                .to_str()
+                .unwrap()
+                .to_string(),
+            page_centrality_store_path: None,
+            safety_classifier_path: None,
+            host_centrality_threshold: None,
+            minimum_clean_words: None,
+            cluster_id: "test-cluster".to_string(),
+            gossip_seed_nodes: gossip_seed,
+            gossip_addr,
+            shard_id: shard,
+            index_path: path.as_path().join("index").to_str().unwrap().to_string(),
+            linear_model_path: None,
+            lambda_model_path: None,
+            host,
+            collector: Default::default(),
+            snippet: Default::default(),
+        };
+
+        let service = LiveIndexService::new(config).await?;
+        let cluster = service.cluster_handle.clone();
+        let index = service.index.clone();
+
+        service.background_setup();
+
+        let server = service.bind(&host).await.unwrap();
+
+        tokio::task::spawn(async move {
+            loop {
+                if let Err(e) = server.accept().await {
+                    tracing::error!("{:?}", e);
+                }
+            }
+        });
+
+        Ok(Self {
+            host,
+            shard,
+            gossip_addr,
+            underlying_index: index,
+            cluster,
+        })
+    }
+
     async fn conn(&self) -> Result<sonic::service::Connection<LiveIndexService>> {
         Ok(sonic::service::Connection::create(self.host).await?)
     }
@@ -64,13 +139,10 @@ impl RemoteIndex {
     async fn await_ready(&self, cluster: &Cluster) {
         cluster
             .await_member(|member| {
-                if let Service::LiveIndex {
-                    host: _,
-                    shard,
-                    state,
-                } = member.service.clone()
-                {
-                    self.shard == shard && matches!(state, LiveIndexState::Ready)
+                if let Service::LiveIndex { host, shard, state } = member.service.clone() {
+                    self.shard == shard
+                        && matches!(state, LiveIndexState::Ready)
+                        && host == self.host
                 } else {
                     false
                 }
@@ -78,9 +150,37 @@ impl RemoteIndex {
             .await;
     }
 
-    async fn commit_underlying(&self) -> Result<()> {
-        let index = Arc::clone(&self.underlying_index);
-        tokio::task::spawn_blocking(move || index.commit()).await?;
+    async fn search(&self, query: &str) -> Result<Vec<inverted_index::RetrievedWebpage>> {
+        let mut conn = self.conn().await?;
+
+        let websites: Vec<inverted_index::WebpagePointer> = conn
+            .send(search_server::Search {
+                query: query.to_string().into(),
+            })
+            .await?
+            .map(|res| {
+                res.websites
+                    .into_iter()
+                    .map(|page| page.pointer().clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(conn
+            .send(search_server::RetrieveWebsites {
+                websites,
+                query: query.to_string(),
+            })
+            .await?
+            .unwrap())
+    }
+
+    async fn commit_underlying(&self) {
+        self.underlying_index.commit();
+    }
+
+    async fn kill(self) -> Result<()> {
+        self.cluster.remove_service().await?;
 
         Ok(())
     }
@@ -88,14 +188,10 @@ impl RemoteIndex {
 
 const CLUSTER_ID: &str = "test-cluster";
 
-async fn start_index(shard: ShardId, gossip: Vec<SocketAddr>) -> Result<RemoteIndex> {
-    todo!()
-}
-
 #[tokio::test]
 async fn test_shard_without_replica() -> Result<()> {
-    let shard1 = start_index(ShardId::new(1), vec![]).await?;
-    let shard2 = start_index(ShardId::new(2), vec![shard1.gossip_addr]).await?;
+    let shard1 = RemoteIndex::start(ShardId::new(1), vec![]).await?;
+    let shard2 = RemoteIndex::start(ShardId::new(2), vec![shard1.gossip_addr]).await?;
 
     let cluster = Cluster::join_as_spectator(
         CLUSTER_ID.to_string(),
@@ -136,23 +232,199 @@ async fn test_shard_without_replica() -> Result<()> {
         )
         .await?;
 
-    shard1.commit_underlying().await?;
-    shard2.commit_underlying().await?;
+    shard1.commit_underlying().await;
+    shard2.commit_underlying().await;
 
-    todo!("test searches");
+    let res1 = shard1.search("test").await?;
+
+    assert_eq!(res1.len(), 1);
+    assert_eq!(res1[0].url, "https://a.com/");
+
+    let res2 = shard2.search("test").await?;
+    assert_eq!(res2.len(), 1);
+    assert_eq!(res2[0].url, "https://b.com/");
+
+    Ok(())
 }
 
 #[tokio::test]
 async fn test_replica_no_fails() -> Result<()> {
-    todo!("start cluster with shard1_rep1 and shard1_rep2, insert some pages and check they are all indexed");
+    let rep1 = RemoteIndex::start(ShardId::new(1), vec![]).await?;
+    let rep2 = RemoteIndex::start(ShardId::new(1), vec![rep1.gossip_addr]).await?;
+
+    let cluster = Cluster::join_as_spectator(
+        CLUSTER_ID.to_string(),
+        free_socket_addr(),
+        vec![rep1.gossip_addr],
+    )
+    .await?;
+
+    rep1.await_ready(&cluster).await;
+    rep2.await_ready(&cluster).await;
+
+    rep1.index_pages(
+        vec![IndexableWebpage {
+            url: "https://a.com/".to_string(),
+            body: "
+                <title>test page</title>
+                Example webpage
+                "
+            .to_string(),
+            fetch_time_ms: 100,
+        }],
+        Some(1.0),
+    )
+    .await?;
+    rep2.index_pages(
+        vec![IndexableWebpage {
+            url: "https://b.com/".to_string(),
+            body: "
+                <title>test page</title>
+                Example webpage
+                "
+            .to_string(),
+            fetch_time_ms: 100,
+        }],
+        Some(1.0),
+    )
+    .await?;
+
+    rep1.commit_underlying().await;
+    rep2.commit_underlying().await;
+
+    let res1 = rep1.search("test").await?;
+
+    assert_eq!(res1.len(), 2);
+
+    let res2 = rep2.search("test").await?;
+    assert_eq!(res2.len(), 2);
+
+    Ok(())
 }
 
 #[tokio::test]
 async fn test_replica_setup_after_inserts() -> Result<()> {
-    todo!("start cluser with shard1_rep1, insert page, start shard1_rep2, check that shard1_rep2 has page");
+    let rep1 = RemoteIndex::start(ShardId::new(1), vec![]).await?;
+
+    let cluster = Cluster::join_as_spectator(
+        CLUSTER_ID.to_string(),
+        free_socket_addr(),
+        vec![rep1.gossip_addr],
+    )
+    .await?;
+
+    rep1.await_ready(&cluster).await;
+
+    rep1.index_pages(
+        vec![IndexableWebpage {
+            url: "https://a.com/".to_string(),
+            body: "
+                <title>test page</title>
+                Example webpage
+                "
+            .to_string(),
+            fetch_time_ms: 100,
+        }],
+        Some(1.0),
+    )
+    .await?;
+    rep1.index_pages(
+        vec![IndexableWebpage {
+            url: "https://b.com/".to_string(),
+            body: "
+                <title>test page</title>
+                Example webpage
+                "
+            .to_string(),
+            fetch_time_ms: 100,
+        }],
+        Some(1.0),
+    )
+    .await?;
+
+    rep1.commit_underlying().await;
+
+    let rep2 = RemoteIndex::start(ShardId::new(1), vec![rep1.gossip_addr]).await?;
+    rep2.await_ready(&cluster).await;
+
+    rep2.commit_underlying().await;
+
+    let res1 = rep1.search("test").await?;
+
+    assert_eq!(res1.len(), 2);
+
+    let res2 = rep2.search("test").await?;
+    assert_eq!(res2.len(), 2);
+
+    Ok(())
 }
 
 #[tokio::test]
 async fn test_replica_recovery() -> Result<()> {
-    todo!("start cluser with shard1_rep1 shard1_rep2, insert page, kill shard1_rep2, insert another page, start shard1_rep2, check that shard1_rep2 has both pages");
+    let rep1 = RemoteIndex::start(ShardId::new(1), vec![]).await?;
+    let rep2 = RemoteIndex::start(ShardId::new(1), vec![rep1.gossip_addr]).await?;
+
+    let cluster = Cluster::join_as_spectator(
+        CLUSTER_ID.to_string(),
+        free_socket_addr(),
+        vec![rep1.gossip_addr],
+    )
+    .await?;
+
+    rep1.await_ready(&cluster).await;
+    rep2.await_ready(&cluster).await;
+
+    rep1.index_pages(
+        vec![IndexableWebpage {
+            url: "https://a.com/".to_string(),
+            body: "
+                <title>test page</title>
+                Example webpage
+                "
+            .to_string(),
+            fetch_time_ms: 100,
+        }],
+        Some(1.0),
+    )
+    .await?;
+
+    rep2.kill().await?;
+
+    loop {
+        if let Ok(_) = rep1
+            .index_pages(
+                vec![IndexableWebpage {
+                    url: "https://b.com/".to_string(),
+                    body: "
+                    <title>test page</title>
+                    Example webpage
+                    "
+                    .to_string(),
+                    fetch_time_ms: 100,
+                }],
+                Some(1.0),
+            )
+            .await
+        {
+            break;
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+
+    rep1.commit_underlying().await;
+
+    let rep2 = RemoteIndex::start(ShardId::new(1), vec![rep1.gossip_addr]).await?;
+    rep2.await_ready(&cluster).await;
+
+    rep2.commit_underlying().await;
+
+    let res1 = rep1.search("test").await?;
+
+    assert_eq!(res1.len(), 2);
+
+    let res2 = rep2.search("test").await?;
+    assert_eq!(res2.len(), 2);
+
+    Ok(())
 }

--- a/crates/core/src/inverted_index/search.rs
+++ b/crates/core/src/inverted_index/search.rs
@@ -63,6 +63,13 @@ impl InvertedIndex {
         let mut query: Box<dyn tantivy::query::Query> = Box::new(query.clone());
 
         if let Some(limit) = collector.top_docs().max_docs().cloned() {
+            if limit.segments == 0 {
+                return Ok(InitialSearchResult {
+                    num_websites: approx_count::Count::Exact(0),
+                    top_websites: vec![],
+                });
+            }
+
             let docs_per_segment = (limit.total_docs / limit.segments) as u64;
             query = Box::new(ShortCircuitQuery::new(query, docs_per_segment));
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod autosuggest;
 mod backlink_grouper;
 pub mod bangs;
 mod bincode_utils;
+mod block_on;
 pub mod canon_index;
 mod collector;
 pub mod config;
@@ -93,17 +94,7 @@ pub mod webgraph;
 pub mod webpage;
 mod widgets;
 
-static TOKIO_RUNTIME: std::sync::LazyLock<tokio::runtime::Runtime> =
-    std::sync::LazyLock::new(|| {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-    });
-
-pub fn block_on<F: std::future::Future>(f: F) -> F::Output {
-    TOKIO_RUNTIME.block_on(f)
-}
+pub use block_on::block_on;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/crates/core/src/live_index/index.rs
+++ b/crates/core/src/live_index/index.rs
@@ -28,8 +28,8 @@ use tantivy::index::SegmentId;
 use std::collections::{HashMap, HashSet};
 
 use crate::{
-    config::{LiveIndexConfig, SnippetConfig},
-    entrypoint::indexer::{IndexableWebpage, IndexingWorker},
+    config::SnippetConfig,
+    entrypoint::indexer::{self, IndexableWebpage, IndexingWorker},
     live_index::{BATCH_SIZE, TTL},
     searcher::SearchableIndex,
     Result,
@@ -84,17 +84,19 @@ pub struct InnerIndex {
 }
 
 impl InnerIndex {
-    pub fn new(config: LiveIndexConfig) -> Result<Self> {
-        let path = Path::new(&config.index_path);
-        let mut index = crate::index::Index::open(path.join("index"))?;
+    pub fn new<P: AsRef<Path>>(
+        path: P,
+        indexer_worker_config: indexer::worker::Config,
+    ) -> Result<Self> {
+        let mut index = crate::index::Index::open(path.as_ref().join("index"))?;
         index.prepare_writer()?;
 
-        let write_ahead_log = Wal::open(path.join("wal"))?;
+        let write_ahead_log = Wal::open(path.as_ref().join("wal"))?;
         let wal_count = write_ahead_log.iter()?.count();
 
-        let worker = IndexingWorker::new(config.clone());
+        let worker = IndexingWorker::new(indexer_worker_config);
 
-        let meta = Meta::open_or_create(path.join("meta.json"));
+        let meta = Meta::open_or_create(path.as_ref().join("meta.json"));
 
         Ok(Self {
             index,
@@ -102,7 +104,7 @@ impl InnerIndex {
             indexing_worker: worker,
             has_inserts: wal_count > 0,
             meta,
-            path: path.to_path_buf(),
+            path: path.as_ref().to_path_buf(),
         })
     }
 
@@ -192,12 +194,25 @@ impl InnerIndex {
                 created: Utc::now(),
             })
         }
+    }
 
+    fn save_meta(&self) {
         self.meta.save(self.path.join("meta.json"));
     }
 
     pub fn index(&self) -> &crate::index::Index {
         &self.index
+    }
+
+    pub fn delete_all_pages(&mut self) {
+        let segments = self.index.inverted_index.segment_ids();
+        self.index
+            .inverted_index
+            .delete_segments_by_id(&segments)
+            .unwrap();
+
+        self.meta = Meta::default();
+        self.save_meta()
     }
 
     pub fn insert(&mut self, pages: &[IndexableWebpage]) {
@@ -226,6 +241,10 @@ impl InnerIndex {
     pub fn has_inserts(&self) -> bool {
         self.has_inserts
     }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 pub struct LiveIndex {
@@ -233,9 +252,12 @@ pub struct LiveIndex {
 }
 
 impl LiveIndex {
-    pub fn new(config: LiveIndexConfig) -> Result<Self> {
+    pub fn new<P: AsRef<Path>>(
+        path: P,
+        indexer_worker_config: indexer::worker::Config,
+    ) -> Result<Self> {
         Ok(Self {
-            inner: Arc::new(RwLock::new(InnerIndex::new(config)?)),
+            inner: Arc::new(RwLock::new(InnerIndex::new(path, indexer_worker_config)?)),
         })
     }
 
@@ -284,5 +306,20 @@ impl LiveIndex {
             .unwrap_or_else(|e| e.into_inner())
             .index
             .set_snippet_config(config)
+    }
+
+    pub fn path(&self) -> PathBuf {
+        self.inner
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .path
+            .to_path_buf()
+    }
+
+    pub fn delete_all_pages(&self) {
+        self.inner
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .delete_all_pages();
     }
 }

--- a/crates/core/src/live_index/index_manager.rs
+++ b/crates/core/src/live_index/index_manager.rs
@@ -18,12 +18,9 @@ use std::sync::Arc;
 
 use chrono::Utc;
 
-use crate::config::LiveIndexConfig;
-
 use super::{
     LiveIndex, AUTO_COMMIT_INTERVAL, COMPACT_INTERVAL, EVENT_LOOP_INTERVAL, PRUNE_INTERVAL,
 };
-use crate::Result;
 
 pub struct IndexManager {
     index: Arc<LiveIndex>,

--- a/crates/core/src/live_index/index_manager.rs
+++ b/crates/core/src/live_index/index_manager.rs
@@ -30,12 +30,11 @@ pub struct IndexManager {
 }
 
 impl IndexManager {
-    pub fn new(config: LiveIndexConfig) -> Result<Self> {
-        let index = Arc::new(LiveIndex::new(config.clone())?);
-        Ok(Self { index })
+    pub fn new(index: Arc<LiveIndex>) -> Self {
+        Self { index }
     }
 
-    pub async fn run(self) {
+    pub fn run(self) {
         let mut last_commit = Utc::now();
         let mut last_prune = Utc::now();
         let mut last_compact = Utc::now();
@@ -56,7 +55,7 @@ impl IndexManager {
                 last_compact = Utc::now();
             }
 
-            tokio::time::sleep(EVENT_LOOP_INTERVAL).await;
+            std::thread::sleep(EVENT_LOOP_INTERVAL);
         }
     }
 

--- a/crates/core/src/live_index/index_manager.rs
+++ b/crates/core/src/live_index/index_manager.rs
@@ -55,8 +55,4 @@ impl IndexManager {
             std::thread::sleep(EVENT_LOOP_INTERVAL);
         }
     }
-
-    pub fn index(&self) -> Arc<LiveIndex> {
-        self.index.clone()
-    }
 }

--- a/crates/core/src/ranking/mod.rs
+++ b/crates/core/src/ranking/mod.rs
@@ -756,7 +756,7 @@ mod tests {
     }
 
     fn setup_worker(data_path: &Path) -> IndexingWorker {
-        IndexingWorker::new(
+        crate::block_on(IndexingWorker::new(
             IndexerConfig {
                 host_centrality_store_path: crate::gen_temp_path().to_str().unwrap().to_string(),
                 page_centrality_store_path: None,
@@ -780,7 +780,7 @@ mod tests {
                     crate::config::defaults::Indexing::autocommit_after_num_inserts(),
             }
             .into(),
-        )
+        ))
     }
 
     #[test]

--- a/crates/core/src/ranking/mod.rs
+++ b/crates/core/src/ranking/mod.rs
@@ -756,28 +756,31 @@ mod tests {
     }
 
     fn setup_worker(data_path: &Path) -> IndexingWorker {
-        IndexingWorker::new(IndexerConfig {
-            host_centrality_store_path: crate::gen_temp_path().to_str().unwrap().to_string(),
-            page_centrality_store_path: None,
-            page_webgraph: None,
-            safety_classifier_path: None,
-            dual_encoder: Some(IndexerDualEncoderConfig {
-                model_path: data_path.to_str().unwrap().to_string(),
-                page_centrality_rank_threshold: None,
-            }),
-            output_path: crate::gen_temp_path().to_str().unwrap().to_string(),
-            limit_warc_files: None,
-            skip_warc_files: None,
-            warc_source: WarcSource::Local(crate::config::LocalConfig {
-                folder: crate::gen_temp_path().to_str().unwrap().to_string(),
-                names: vec!["".to_string()],
-            }),
-            host_centrality_threshold: None,
-            minimum_clean_words: None,
-            batch_size: 10,
-            autocommit_after_num_inserts:
-                crate::config::defaults::Indexing::autocommit_after_num_inserts(),
-        })
+        IndexingWorker::new(
+            IndexerConfig {
+                host_centrality_store_path: crate::gen_temp_path().to_str().unwrap().to_string(),
+                page_centrality_store_path: None,
+                page_webgraph: None,
+                safety_classifier_path: None,
+                dual_encoder: Some(IndexerDualEncoderConfig {
+                    model_path: data_path.to_str().unwrap().to_string(),
+                    page_centrality_rank_threshold: None,
+                }),
+                output_path: crate::gen_temp_path().to_str().unwrap().to_string(),
+                limit_warc_files: None,
+                skip_warc_files: None,
+                warc_source: WarcSource::Local(crate::config::LocalConfig {
+                    folder: crate::gen_temp_path().to_str().unwrap().to_string(),
+                    names: vec!["".to_string()],
+                }),
+                host_centrality_threshold: None,
+                minimum_clean_words: None,
+                batch_size: 10,
+                autocommit_after_num_inserts:
+                    crate::config::defaults::Indexing::autocommit_after_num_inserts(),
+            }
+            .into(),
+        )
     }
 
     #[test]

--- a/crates/core/src/searcher/api/mod.rs
+++ b/crates/core/src/searcher/api/mod.rs
@@ -453,7 +453,7 @@ where
     async fn search_initial_from_live(
         &self,
         query: &SearchQuery,
-    ) -> Option<Vec<live::InitialSearchResultSplit>> {
+    ) -> Option<Vec<live::InitialSearchResultShard>> {
         match &self.live_searcher {
             Some(searcher) => Some(searcher.search_initial(query).await),
             None => None,
@@ -482,7 +482,7 @@ where
         &self,
         query: &SearchQuery,
         initial_results: Vec<distributed::InitialSearchResultShard>,
-        live_results: Vec<live::InitialSearchResultSplit>,
+        live_results: Vec<live::InitialSearchResultShard>,
     ) -> (Vec<ScoredWebpagePointer>, bool) {
         let mut collector =
             BucketCollector::new(NUM_PIPELINE_RANKING_RESULTS, self.collector_config.clone());
@@ -542,7 +542,7 @@ where
                     .unwrap_or_default();
                 let pointer = live::ScoredWebpagePointer {
                     website: RecallRankingWebpage::new(website, inbound),
-                    split_id: result.split_id.clone(),
+                    shard_id: result.shard_id,
                 };
 
                 let pointer = ScoredWebpagePointer::Live(pointer);

--- a/crates/core/src/searcher/mod.rs
+++ b/crates/core/src/searcher/mod.rs
@@ -83,6 +83,16 @@ pub struct SearchQuery {
     pub signal_coefficients: SignalCoefficients,
 }
 
+#[cfg(test)]
+impl From<String> for SearchQuery {
+    fn from(query: String) -> Self {
+        Self {
+            query,
+            ..Default::default()
+        }
+    }
+}
+
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode)]
 pub struct InitialWebsiteResult {
     pub num_websites: Count,


### PR DESCRIPTION
This adds eventually consistent replication inspired by elastisearch to the live index.

All writes are first written to a WAL, then replicated to desired quorom of 'ready' replicas before returning 'success' to the client. The client is always  expected to endlessly retry requests untill they are successfully indexed/replicated.

When a node first joins a cluster it's in setup mode and does not count towards the required quorom. The node checks if there are existing replicas in the cluster for the same shard as itself. If there is, the index is downloaded from one of the existing replicas.

While the new node is in setup mode, writes are still replicated to it and written to a temporary WAL while the index is being downloaded. When the index has been downloaded, the items in the temporary WAL is added to the primary WAL to be included in the index. After this is done, the node is marked as 'ready' in the cluster and can participate in the quorom and receive search requests.

The following scenarios have been tested:
* Inserting webpages without failures (happy path).
* A node joining after inserts.
* Failure recovery where a node crashes, inserts are performed to another replica and the original node then comes back online and gets the missing inserts from the replica.