### PR TITLE
Use nom in zimba parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6516,6 +6516,7 @@ version = "0.1.0"
 dependencies = [
  "lzma",
  "memmap2",
+ "nom",
  "thiserror",
  "zstd 0.13.2",
 ]

--- a/crates/zimba/Cargo.toml
+++ b/crates/zimba/Cargo.toml
@@ -6,7 +6,8 @@ version = "0.1.0"
 license = "MIT"
 
 [dependencies]
-lzma = {workspace = true}
-memmap2 = {workspace = true}
-thiserror = {workspace = true}
-zstd = {workspace = true}
+lzma = { workspace = true }
+memmap2 = { workspace = true }
+thiserror = { workspace = true }
+zstd = { workspace = true }
+nom = { workspace = true }

--- a/crates/zimba/src/wiki.rs
+++ b/crates/zimba/src/wiki.rs
@@ -1,5 +1,5 @@
 // Stract is an open source web search engine.
-// Copyright (C) 2023 Stract ApS
+// Copyright (C) 2024 Stract ApS
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
This makes zimba more robust and easier to maintain in preparation for moving it to a separate module