### PR TITLE
Sanitise bang redirects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5068,6 +5068,7 @@ dependencies = [
  "unicode-normalization",
  "unicode-segmentation",
  "url",
+ "urlencoding",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
@@ -5930,6 +5931,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ whatlang = { version = "0.16.0", features = ["serde"] }
 xxhash-rust = { version = "0.8.10", features = ["xxh3", "const_xxh3"] }
 zipf = "7.0.0"
 zstd = { version = "0.13", features = ["experimental"] }
+urlencoding = "2.1.3"
 
 [profile.test.package]
 flate2.opt-level = 3

--- a/assets/licenses.html
+++ b/assets/licenses.html
@@ -45,7 +45,7 @@
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
             <li><a href="#Apache-2.0">Apache License 2.0</a> (411)</li>
-            <li><a href="#MIT">MIT License</a> (190)</li>
+            <li><a href="#MIT">MIT License</a> (191)</li>
             <li><a href="#AGPL-3.0">GNU Affero General Public License v3.0</a> (9)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (9)</li>
             <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (8)</li>
@@ -14111,6 +14111,34 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/kornelski/rust_urlencoding ">urlencoding 2.1.3</a></li>
+                </ul>
+                <pre class="license-text">© 2016 Bertram Truong
+© 2021 Kornel Lesiński
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 </pre>
             </li>
             <li class="license">

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -116,6 +116,7 @@ utoipa.workspace = true
 uuid.workspace = true
 whatlang.workspace = true
 zimba = { path = "../zimba" }
+urlencoding.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator.workspace = true

--- a/crates/core/src/bangs.rs
+++ b/crates/core/src/bangs.rs
@@ -169,7 +169,7 @@ impl Bangs {
                 )
                 .collect::<String>();
 
-                let query = crate::urlencode(query.as_str());
+                let query = urlencoding::encode(query.as_str()).into_owned();
                 let url = bang.url.replace("{{{s}}}", query.as_str());
 
                 return Url::parse(url.as_str())

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -396,17 +396,6 @@ pub fn mv<P1: AsRef<std::path::Path>, P2: AsRef<std::path::Path>>(
     Ok(())
 }
 
-pub fn urlencode(s: &str) -> String {
-    const FRAGMENT: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
-        .add(b' ')
-        .add(b'"')
-        .add(b'<')
-        .add(b'>')
-        .add(b'`');
-
-    percent_encoding::utf8_percent_encode(s, FRAGMENT).to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/searcher/api/mod.rs
+++ b/crates/core/src/searcher/api/mod.rs
@@ -304,7 +304,7 @@ where
             .collect();
 
             let mut query = query.clone();
-            query.query = q;
+            query.query = urlencoding::encode(&q).into_owned();
 
             let res = self.search_websites(&query).await?;
 


### PR DESCRIPTION
url encode user queries when forwarding to bang location to prevent open redirect vulnerabilities